### PR TITLE
feat: add SQLite to Postgres migration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:clean-expired": "tsx scripts/optimize-database.ts clean-expired",
     "db:backup": "./scripts/backup-database.sh full",
     "db:test-connection": "tsx scripts/test-db-connection.ts",
+    "db:migrate-data": "node scripts/migrate-to-postgres.js",
     "vps:setup": "powershell -ExecutionPolicy Bypass -File scripts/setup-vps.ps1",
     "postinstall": "prisma generate"
   },

--- a/scripts/migrate-to-postgres.js
+++ b/scripts/migrate-to-postgres.js
@@ -1,0 +1,69 @@
+const { execFileSync } = require('child_process');
+const { PrismaClient } = require('@prisma/client');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+// Path to the SQLite database; default to dev.db in repo root
+const sqlitePath = process.env.SQLITE_DB_PATH || path.join(__dirname, '..', 'dev.db');
+
+if (!fs.existsSync(sqlitePath)) {
+  console.log(`No SQLite database found at ${sqlitePath}. Nothing to migrate.`);
+  process.exit(0);
+}
+
+const prisma = new PrismaClient();
+
+function runSqlite(sql) {
+  const output = execFileSync('sqlite3', ['-json', sqlitePath, sql], { encoding: 'utf8' }).trim();
+  return output ? JSON.parse(output) : [];
+}
+
+async function migrate() {
+  const tables = runSqlite(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';"
+  ).map(t => t.name);
+
+  if (tables.length === 0) {
+    console.log('No tables found in SQLite database. Exiting.');
+    return;
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Disable triggers and constraints for faster import
+      await tx.$executeRawUnsafe("SET session_replication_role = 'replica'");
+
+      for (const table of tables) {
+        const rows = runSqlite(`SELECT * FROM "${table}";`);
+        for (const row of rows) {
+          const columns = Object.keys(row).map(c => `"${c}"`).join(', ');
+          const placeholders = Object.keys(row).map((_, i) => `$${i + 1}`).join(', ');
+          const values = Object.values(row);
+          await tx.$executeRawUnsafe(`INSERT INTO "${table}" (${columns}) VALUES (${placeholders})`, ...values);
+        }
+
+        // Verify integrity by comparing row counts
+        const sqliteCount = runSqlite(`SELECT COUNT(*) AS count FROM "${table}";`)[0].count;
+        const pgCountRes = await tx.$queryRawUnsafe(`SELECT COUNT(*)::int AS count FROM "${table}";`);
+        const pgCount = pgCountRes[0].count;
+        if (sqliteCount !== pgCount) {
+          throw new Error(`Integrity check failed for ${table}: SQLite=${sqliteCount}, PostgreSQL=${pgCount}`);
+        }
+        console.log(`Migrated ${table}: ${pgCount} rows`);
+      }
+
+      await tx.$executeRawUnsafe("SET session_replication_role = 'origin'");
+    });
+
+    console.log('Migration completed successfully.');
+  } catch (err) {
+    console.error('Migration failed. PostgreSQL transaction rolled back.');
+    console.error(err);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+migrate();
+


### PR DESCRIPTION
## Summary
- add migration script to move data from SQLite to PostgreSQL with transaction rollback and row-count verification
- expose script as `db:migrate-data` npm command

## Testing
- `node scripts/migrate-to-postgres.js`
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0b147e0bc8320a8444f05bb8c884f