### PR TITLE
Add analytics chart and real-time notifications

### DIFF
--- a/src/app/admin/notificaciones/page.tsx
+++ b/src/app/admin/notificaciones/page.tsx
@@ -1,0 +1,12 @@
+import { AdminNotificationCenter } from '@/components/notifications/AdminNotificationCenter'
+
+export const dynamic = 'force-dynamic'
+
+export default function AdminNotificationsPage() {
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Centro de Notificaciones</h1>
+      <AdminNotificationCenter />
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/badge'
+import { SalesChart } from '@/components/analytics/SalesChart'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { 
@@ -198,6 +199,10 @@ export default function AdminDashboard() {
     }
   }
 
+  const handleExport = () => {
+    window.open('/api/admin/export/ventas', '_blank')
+  }
+
   useEffect(() => {
     const initDashboard = async () => {
       const isAuthenticated = await checkAuth()
@@ -257,6 +262,7 @@ export default function AdminDashboard() {
           
           {/* Botones */}
           <div className="flex items-center gap-2">
+            <Button onClick={handleExport} variant="outline" size="sm">Exportar CSV</Button>
             <Button onClick={cargarDashboard} disabled={refreshing} variant="outline" size="sm">
               <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
               Actualizar
@@ -405,6 +411,14 @@ export default function AdminDashboard() {
               </CardContent>
             </Card>
           </div>
+          <Card>
+            <CardHeader>
+              <CardTitle>Ventas últimos 7 días</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SalesChart />
+            </CardContent>
+          </Card>
         </TabsContent>
 
         <TabsContent value="payments" className="space-y-4">

--- a/src/app/api/admin/analytics/ventas/route.ts
+++ b/src/app/api/admin/analytics/ventas/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { MOCK_MODE } from '@/lib/mock-data'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const now = new Date()
+    const start = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000)
+
+    if (MOCK_MODE) {
+      const data = Array.from({ length: 7 }).map((_, i) => {
+        const d = new Date(start.getTime() + i * 24 * 60 * 60 * 1000)
+        return { fecha: d.toISOString().slice(0, 10), monto: Math.floor(Math.random() * 1000) }
+      })
+      return NextResponse.json({ success: true, data })
+    }
+
+    const ventas = await prisma.compra.findMany({
+      where: {
+        estadoPago: 'APROBADO' as any,
+        createdAt: { gte: start }
+      },
+      select: { monto: true, createdAt: true }
+    })
+
+    const map = new Map<string, number>()
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(start.getTime() + i * 24 * 60 * 60 * 1000)
+      map.set(date.toISOString().slice(0, 10), 0)
+    }
+    ventas.forEach(v => {
+      const key = v.createdAt.toISOString().slice(0, 10)
+      map.set(key, (map.get(key) || 0) + v.monto)
+    })
+
+    const data = Array.from(map.entries()).map(([fecha, monto]) => ({ fecha, monto }))
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    console.error('Error al obtener ventas:', error)
+    return NextResponse.json({ success: false, error: 'Error al obtener ventas' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/export/ventas/route.ts
+++ b/src/app/api/admin/export/ventas/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const ventas = await prisma.compra.findMany({
+      select: {
+        id: true,
+        monto: true,
+        createdAt: true,
+        participante: { select: { nombre: true } }
+      }
+    })
+
+    const rows = ['id,participante,monto,fecha']
+    ventas.forEach(v => {
+      const fecha = v.createdAt.toISOString()
+      const nombre = v.participante?.nombre || ''
+      rows.push(`${v.id},${nombre},${v.monto},${fecha}`)
+    })
+
+    return new NextResponse(rows.join('\n'), {
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': 'attachment; filename="ventas.csv"'
+      }
+    })
+  } catch (error) {
+    console.error('Error exportando ventas:', error)
+    return NextResponse.json({ success: false, error: 'Error exportando ventas' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/notificaciones/route.ts
+++ b/src/app/api/admin/notificaciones/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export const dynamic = 'force-dynamic'
 
 import { prisma } from '@/lib/prisma'
+import { emitNotification } from '@/lib/notificationEmitter'
 import { z } from 'zod'
 
 const MarcarLeidaSchema = z.object({
@@ -152,6 +153,7 @@ export async function POST(request: NextRequest) {
           creadaPor: adminId
         }
       })
+        emitNotification({ id: notificacion.id, tipo: notificacion.tipo, titulo: notificacion.titulo, mensaje: notificacion.mensaje })
       
       // Registro de auditoría
       await prisma.auditLog.create({

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,27 @@
+import { notificationEmitter } from '@/lib/notificationEmitter'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  let onNotification: any
+  const stream = new ReadableStream({
+    start(controller) {
+      onNotification = (data: any) => {
+        controller.enqueue(`data: ${JSON.stringify(data)}\n\n`)
+      }
+      notificationEmitter.on('notification', onNotification)
+      controller.enqueue(': connected\n\n')
+    },
+    cancel() {
+      notificationEmitter.off('notification', onNotification)
+    }
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    }
+  })
+}

--- a/src/components/analytics/SalesChart.tsx
+++ b/src/components/analytics/SalesChart.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Point {
+  fecha: string
+  monto: number
+}
+
+export function SalesChart() {
+  const [data, setData] = useState<Point[]>([])
+
+  useEffect(() => {
+    fetch('/api/admin/analytics/ventas')
+      .then(res => res.json())
+      .then(res => {
+        if (res.success) setData(res.data)
+      })
+  }, [])
+
+  const max = Math.max(...data.map(d => d.monto), 0)
+
+  return (
+    <div className="w-full">
+      <div className="flex items-end h-40 space-x-2">
+        {data.map((p) => (
+          <div key={p.fecha} className="flex-1 flex flex-col items-center">
+            <div
+              className="w-full bg-blue-500 rounded-sm"
+              style={{ height: max ? `${(p.monto / max) * 100}%` : '0%' }}
+            ></div>
+            <span className="text-xs mt-1">{p.fecha.slice(5, 10)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/notifications/AdminNotificationCenter.tsx
+++ b/src/components/notifications/AdminNotificationCenter.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+
+interface Notification {
+  id: string
+  titulo: string
+  mensaje: string
+  leida: boolean
+  createdAt?: string
+}
+
+export function AdminNotificationCenter() {
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [filter, setFilter] = useState<'all' | 'unread'>('all')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    fetch('/api/admin/notificaciones?limit=50')
+      .then(res => res.json())
+      .then(data => {
+        if (data.success) {
+          setNotifications(data.data || [])
+        }
+      })
+
+    const es = new EventSource('/api/notifications/stream')
+    es.onmessage = (e) => {
+      try {
+        const notif = JSON.parse(e.data)
+        setNotifications(prev => [
+          { ...notif, leida: false },
+          ...prev,
+        ])
+      } catch (err) {
+        console.error('Error parsing notification', err)
+      }
+    }
+    return () => es.close()
+  }, [])
+
+  const filtered = notifications.filter(n => {
+    if (filter === 'unread' && n.leida) return false
+    if (search && !n.titulo.toLowerCase().includes(search.toLowerCase()) &&
+        !n.mensaje.toLowerCase().includes(search.toLowerCase())) return false
+    return true
+  })
+
+  const markAllRead = async () => {
+    await fetch('/api/admin/notificaciones', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ adminId: 'admin-demo' })
+    })
+    setNotifications(prev => prev.map(n => ({ ...n, leida: true })))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Input
+          placeholder="Buscar..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <Button onClick={markAllRead} variant="outline">Marcar todas como leídas</Button>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          variant={filter === 'all' ? 'default' : 'outline'}
+          onClick={() => setFilter('all')}
+        >
+          Todas
+        </Button>
+        <Button
+          variant={filter === 'unread' ? 'default' : 'outline'}
+          onClick={() => setFilter('unread')}
+        >
+          No leídas
+        </Button>
+      </div>
+      <ul className="space-y-2 max-h-80 overflow-y-auto">
+        {filtered.map(n => (
+          <li
+            key={n.id}
+            className={`border p-3 rounded ${n.leida ? 'bg-gray-100' : 'bg-white'}`}
+          >
+            <p className="font-medium">{n.titulo}</p>
+            <p className="text-sm text-muted-foreground">{n.mensaje}</p>
+          </li>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-center text-muted-foreground">No hay notificaciones</p>
+        )}
+      </ul>
+    </div>
+  )
+}

--- a/src/lib/notificationEmitter.ts
+++ b/src/lib/notificationEmitter.ts
@@ -1,0 +1,14 @@
+import { EventEmitter } from 'events'
+
+export interface NotificationEvent {
+  id: string
+  tipo: string
+  titulo: string
+  mensaje: string
+}
+
+export const notificationEmitter = new EventEmitter()
+
+export function emitNotification(notification: NotificationEvent) {
+  notificationEmitter.emit('notification', notification)
+}


### PR DESCRIPTION
## Summary
- add SSE-based notification stream and notification center page with filter/search
- export sales data as CSV
- show last 7 days sales chart on admin dashboard

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0b469acdc83209c6154a433ff7d1a