### PR TITLE
Secure admin APIs with JWT auth and refresh tokens

### DIFF
--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -34,7 +34,9 @@
     },
     "env_production": {
       "NODE_ENV": "production",
-      "PORT": "3000"
+      "PORT": "3000",
+      "DATABASE_URL": "postgresql://usuario:password@localhost:5432/sistema_rifas",
+      "JWT_SECRET": "cambia-esto-por-un-secreto-seguro"
     }
   }],
   

--- a/prisma/migrations/202508161721_refresh_tokens/migration.sql
+++ b/prisma/migrations/202508161721_refresh_tokens/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+  "id" TEXT NOT NULL,
+  "token_hash" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "revoked" BOOLEAN NOT NULL DEFAULT FALSE,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_token_hash_key" ON "refresh_tokens"("token_hash");
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,8 @@ model Usuario {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  refreshTokens RefreshToken[]
+
   @@map("usuarios")
 }
 
@@ -210,9 +212,21 @@ model Configuracion {
   descripcion String?
   tipo        String   @default("STRING") // STRING, NUMBER, BOOLEAN, JSON
   categoria   String   @default("GENERAL")
-  
+
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   @@map("configuraciones")
+}
+
+model RefreshToken {
+  id        String   @id @default(cuid())
+  tokenHash String   @unique
+  userId    String
+  revoked   Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user Usuario @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("refresh_tokens")
 }

--- a/src/app/api/admin/analytics/ventas/route.ts
+++ b/src/app/api/admin/analytics/ventas/route.ts
@@ -1,11 +1,20 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { MOCK_MODE } from '@/lib/mock-data'
+import { requireAuth, isAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const currentUser = await requireAuth(request)
+    if (!currentUser || !isAdmin(currentUser)) {
+      return NextResponse.json(
+        { success: false, error: 'Acceso denegado' },
+        { status: 403 }
+      )
+    }
+
     const now = new Date()
     const start = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000)
 

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -5,11 +5,18 @@ export const dynamic = 'force-dynamic'
 
 import { prisma } from '@/lib/prisma'
 import { MOCK_MODE, MOCK_STATS } from '@/lib/mock-data'
+import { requireAuth, isAdmin } from '@/lib/auth'
 
 // GET: Dashboard principal con estadísticas
 export async function GET(request: NextRequest) {
   try {
-    // TODO: Verificar autenticación de administrador
+    const currentUser = await requireAuth(request)
+    if (!currentUser || !isAdmin(currentUser)) {
+      return NextResponse.json(
+        { success: false, error: 'Acceso denegado' },
+        { status: 403 }
+      )
+    }
     
     // Si estamos en modo demo/mock, devolver datos ficticios
     if (MOCK_MODE) {

--- a/src/app/api/admin/export/ventas/route.ts
+++ b/src/app/api/admin/export/ventas/route.ts
@@ -1,10 +1,19 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { requireAuth, isAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const currentUser = await requireAuth(request)
+    if (!currentUser || !isAdmin(currentUser)) {
+      return NextResponse.json(
+        { success: false, error: 'Acceso denegado' },
+        { status: 403 }
+      )
+    }
+
     const ventas = await prisma.compra.findMany({
       select: {
         id: true,

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { verifyCredentials, generateJWT, logAuthEvent } from '@/lib/auth'
+import { verifyCredentials, generateJWT, logAuthEvent, saveRefreshToken } from '@/lib/auth'
 import { headers } from 'next/headers'
 
 // Force dynamic rendering for API routes
@@ -41,6 +41,8 @@ export async function POST(request: NextRequest) {
       rememberMe ? '30d' : '7d',
       'refresh'
     )
+
+    await saveRefreshToken(refreshToken, user.id)
 
     // Obtener información del request para auditoría
     const headersList = headers()

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getAuthUser, logAuthEvent } from '@/lib/auth'
+import { getAuthUser, logAuthEvent, deleteRefreshToken } from '@/lib/auth'
 import { headers } from 'next/headers'
 
 // Force dynamic rendering for API routes  
@@ -38,6 +38,11 @@ export async function POST(request: NextRequest) {
       success: true,
       message: 'Logout exitoso'
     })
+
+    const refreshToken = request.cookies.get('refresh-token')?.value
+    if (refreshToken) {
+      await deleteRefreshToken(refreshToken)
+    }
 
     // Eliminar cookies de autenticación
     response.cookies.set('auth-token', '', {


### PR DESCRIPTION
## Summary
- enforce JWT secret and persist refresh tokens for rotation
- secure admin API routes with role checks
- document PostgreSQL settings for production in PM2 config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0bc82cf6c8320b6d8658d6d4fb71d