### PR TITLE
Wrap ticket availability response in data object

### DIFF
--- a/src/app/api/tickets/disponibilidad/route.ts
+++ b/src/app/api/tickets/disponibilidad/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
 
     if (!result.success) {
       return NextResponse.json(
-        { error: 'ID de rifa inválido', issues: result.error.issues },
+        { success: false, error: 'ID de rifa inválido', details: result.error.issues },
         { status: 400 }
       )
     }
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
 
     if (!rifa) {
       return NextResponse.json(
-        { error: 'Rifa no encontrada' },
+        { success: false, error: 'Rifa no encontrada' },
         { status: 404 }
       )
     }
@@ -101,21 +101,24 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({
-      rifa: {
-        id: rifa.id,
-        nombre: rifa.nombre,
-        totalBoletos: rifa.totalBoletos,
-        precioPorBoleto: rifa.precioPorBoleto,
-        limitePorPersona: rifa.limitePorPersona
-      },
-      tickets: disponibilidad,
-      estadisticas
+      success: true,
+      data: {
+        rifa: {
+          id: rifa.id,
+          nombre: rifa.nombre,
+          totalBoletos: rifa.totalBoletos,
+          precioPorBoleto: rifa.precioPorBoleto,
+          limitePorPersona: rifa.limitePorPersona
+        },
+        tickets: disponibilidad,
+        estadisticas
+      }
     })
 
   } catch (error) {
     console.error('Error al consultar disponibilidad:', error)
     return NextResponse.json(
-      { error: 'Error interno del servidor' },
+      { success: false, error: 'Error interno del servidor' },
       { status: 500 }
     )
   }

--- a/src/components/landing/RaffleForm.tsx
+++ b/src/components/landing/RaffleForm.tsx
@@ -63,16 +63,18 @@ export function RaffleForm() {
             // Cargar disponibilidad de tickets para la primera rifa
             const disponibilidadRes = await fetch(`/api/tickets/disponibilidad?rifaId=${primeraRifa.id}`)
             if (disponibilidadRes.ok) {
-              const { data: disponibilidad } = await disponibilidadRes.json()
-              setRifa(disponibilidad.rifa)
-              
-              // Convertir tickets a formato del componente
-              const ticketsFormatted = disponibilidad.tickets.map((ticket: any) => ({
-                numero: ticket.numero,
-                estado: ticket.estado as EstadoTicket,
-                selected: false
-              }))
-              setTickets(ticketsFormatted)
+              const { success, data: disponibilidad } = await disponibilidadRes.json()
+              if (success) {
+                setRifa(disponibilidad.rifa)
+
+                // Convertir tickets a formato del componente
+                const ticketsFormatted = disponibilidad.tickets.map((ticket: any) => ({
+                  numero: ticket.numero,
+                  estado: ticket.estado as EstadoTicket,
+                  selected: false
+                }))
+                setTickets(ticketsFormatted)
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- standardize `/api/tickets/disponibilidad` to return `{ success, data }`
- check API success flag in `RaffleForm` before using ticket availability

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0c6f64a288320adf1f3e5e78613a8