### PR TITLE
fix: ensure hashString uses 32-bit integer

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,7 +75,7 @@ export function hashString(str: string): string {
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i)
     hash = ((hash << 5) - hash) + char
-    hash = hash & hash // Convert to 32bit integer
+    hash |= 0 // Force hash into 32-bit integer range
   }
   return hash.toString(36)
 }


### PR DESCRIPTION
## Summary
- replace no-op bitwise AND with `hash |= 0` in `hashString`
- document purpose of forcing hash into 32-bit range

## Testing
- `node - <<'NODE'
function hashString(str) {
  let hash = 0;
  for (let i = 0; i < str.length; i++) {
    const char = str.charCodeAt(i);
    hash = ((hash << 5) - hash) + char;
    hash |= 0; // Force hash into 32-bit integer range
  }
  return hash.toString(36);
}
console.log(hashString('test'));
NODE`
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a145309c488320ac5d3e7551c47cc1