### PR TITLE
feat: configurable database provider for Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 ﻿# Base de datos
 DATABASE_URL="file:./dev.db"
+# Tipo de base de datos (sqlite, postgresql, etc.)
+DATABASE_PROVIDER="sqlite"
 
 # JWT Secret para autenticación
 JWT_SECRET="cambiar-por-un-secret-muy-seguro-en-produccion"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"  // Cambiar temporalmente a SQLite para desarrollo
+  provider = env("DATABASE_PROVIDER") // Define el proveedor (sqlite, postgresql, etc.) mediante la variable de entorno
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- allow selecting database provider via `DATABASE_PROVIDER` env var
- document `DATABASE_PROVIDER` in example environment config

## Testing
- `npx prisma generate` *(fails: npm error 403 Forbidden fetching prisma)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a149aafb30832089cdc452589b7c55