### PR TITLE
Expose public configuration and payment APIs

### DIFF
--- a/src/app/api/admin/metodos-pago/route.ts
+++ b/src/app/api/admin/metodos-pago/route.ts
@@ -1,23 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthUser } from '@/lib/auth'
+import { GET as publicGet } from '../../metodos-pago/route'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
-  try {
-    const metodos = await prisma.metodoPago.findMany({
-      where: { activo: true },
-      orderBy: { orden: 'asc' }
-    })
-
-    return NextResponse.json({ success: true, data: metodos })
-
-  } catch (error) {
-    console.error('Error obteniendo métodos de pago:', error)
+  const user = await getAuthUser()
+  if (!user || (user.rol !== 'ADMIN' && user.rol !== 'SUPER_ADMIN')) {
     return NextResponse.json(
-      { success: false, error: 'Error obteniendo métodos de pago' },
-      { status: 500 }
+      { success: false, error: 'No autorizado' },
+      { status: 403 }
     )
   }
+
+  return publicGet()
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/admin/redes-sociales/route.ts
+++ b/src/app/api/admin/redes-sociales/route.ts
@@ -1,23 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthUser } from '@/lib/auth'
+import { GET as publicGet } from '../../redes-sociales/route'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
-  try {
-    const redes = await prisma.redSocial.findMany({
-      where: { activo: true },
-      orderBy: { orden: 'asc' }
-    })
-
-    return NextResponse.json({ success: true, data: redes })
-
-  } catch (error) {
-    console.error('Error obteniendo redes sociales:', error)
+  const user = await getAuthUser()
+  if (!user || (user.rol !== 'ADMIN' && user.rol !== 'SUPER_ADMIN')) {
     return NextResponse.json(
-      { success: false, error: 'Error obteniendo redes sociales' },
-      { status: 500 }
+      { success: false, error: 'No autorizado' },
+      { status: 403 }
     )
   }
+
+  return publicGet()
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/compras/route.ts
+++ b/src/app/api/compras/route.ts
@@ -80,10 +80,11 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Verificar método de pago (usar admin API temporalmente)
-    const metodoResponse = await fetch(`${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/admin/metodos-pago`)
-    const metodoData = await metodoResponse.json()
-    const metodoPago = metodoData.data?.find((m: any) => m.id === validatedData.metodoPago.id && m.activo)
+    // Verificar método de pago
+    const metodoResponse = await fetch(`${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/metodos-pago`)
+    const metodoJson = await metodoResponse.json()
+    const metodos = metodoJson?.success ? metodoJson.data : metodoJson
+    const metodoPago = metodos.find((m: any) => m.id === validatedData.metodoPago.id && m.activo)
 
     if (!metodoPago) {
       return NextResponse.json(

--- a/src/app/api/configuracion/route.ts
+++ b/src/app/api/configuracion/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const configuraciones = await prisma.configuracionSitio.findMany({
+      orderBy: { clave: 'asc' }
+    })
+
+    const config = configuraciones.reduce((acc, item) => {
+      try {
+        if (item.tipo === 'json') {
+          acc[item.clave] = JSON.parse(item.valor)
+        } else {
+          acc[item.clave] = item.valor
+        }
+      } catch {
+        acc[item.clave] = item.valor
+      }
+      return acc
+    }, {} as Record<string, any>)
+
+    return NextResponse.json({ success: true, data: config })
+  } catch (error) {
+    console.error('Error obteniendo configuraciones:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error obteniendo configuraciones' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/metodos-pago/route.ts
+++ b/src/app/api/metodos-pago/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const metodos = await prisma.metodoPago.findMany({
+      where: { activo: true },
+      orderBy: { orden: 'asc' }
+    })
+
+    return NextResponse.json({ success: true, data: metodos })
+  } catch (error) {
+    console.error('Error obteniendo métodos de pago:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error obteniendo métodos de pago' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/redes-sociales/route.ts
+++ b/src/app/api/redes-sociales/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const redes = await prisma.redSocial.findMany({
+      where: { activo: true },
+      orderBy: { orden: 'asc' }
+    })
+
+    return NextResponse.json({ success: true, data: redes })
+  } catch (error) {
+    console.error('Error obteniendo redes sociales:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error obteniendo redes sociales' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/features/landing/CompraRifa.tsx
+++ b/src/features/landing/CompraRifa.tsx
@@ -101,11 +101,10 @@ export function CompraRifa() {
 
     const cargarMetodosPago = async () => {
       try {
-        const response = await fetch('/api/admin/metodos-pago')
-        const data = await response.json()
-        if (data.success) {
-          setMetodosPago(data.data)
-        }
+        const response = await fetch('/api/metodos-pago')
+        const json = await response.json()
+        const data = json?.success ? json.data : json
+        setMetodosPago(data)
       } catch (error) {
         console.error('Error cargando métodos de pago:', error)
       }
@@ -116,26 +115,29 @@ export function CompraRifa() {
     })
   }, [])
 
-  // Cargar configuración de moneda y colores desde admin/configuracion
+    // Cargar configuración de moneda y colores desde configuracion pública
   useEffect(() => {
     const loadSiteConfig = async () => {
       try {
-        const res = await fetch('/api/admin/configuracion')
-        const data = await res.json()
-        if (data?.success) {
-          const map: Record<string, string> = {}
-          for (const item of data.data || []) map[item.clave] = item.valor
-          // Defaults: Venezuela
-          const code = map['currency_code'] || 'VES'
-          const symbol = map['currency_symbol'] || 'BsS'
-          const locale = map['currency_locale'] || 'es-VE'
-          const position = (map['currency_position'] as 'prefix'|'suffix') || 'suffix'
-          setMoneda({ code, symbol, locale, position })
-          // Colores del tema
-          const colorPrincipal = map['color_principal'] || '#2563eb'
-          const colorSecundario = map['color_secundario'] || '#7c3aed'
-          setTheme({ primary: colorPrincipal, secondary: colorSecundario })
+        const res = await fetch('/api/configuracion')
+        const json = await res.json()
+        const payload = json?.success ? json.data : json
+        const map: Record<string, string> = {}
+        if (Array.isArray(payload)) {
+          for (const item of payload) map[item.clave] = item.valor
+        } else if (payload && typeof payload === 'object') {
+          for (const [k, v] of Object.entries(payload)) map[k] = String(v)
         }
+        // Defaults: Venezuela
+        const code = map['currency_code'] || 'VES'
+        const symbol = map['currency_symbol'] || 'BsS'
+        const locale = map['currency_locale'] || 'es-VE'
+        const position = (map['currency_position'] as 'prefix'|'suffix') || 'suffix'
+        setMoneda({ code, symbol, locale, position })
+        // Colores del tema
+        const colorPrincipal = map['color_principal'] || '#2563eb'
+        const colorSecundario = map['color_secundario'] || '#7c3aed'
+        setTheme({ primary: colorPrincipal, secondary: colorSecundario })
       } catch {}
     }
     loadSiteConfig()

--- a/src/features/landing/FloatingSupportButtons.tsx
+++ b/src/features/landing/FloatingSupportButtons.tsx
@@ -67,7 +67,7 @@ export function FloatingSupportButtons() {
   const [config, setConfig] = useState<SiteConfig>({})
 
   useEffect(() => {
-    fetch('/api/admin/configuracion')
+    fetch('/api/configuracion')
       .then(async (res) => res.json())
       .then((json) => {
         // Tolerar ambas formas: {success, data} o lista/objeto directo

--- a/src/features/landing/NewFooter.tsx
+++ b/src/features/landing/NewFooter.tsx
@@ -20,19 +20,29 @@ export function NewFooter() {
 
   useEffect(() => {
     // Cargar redes sociales
-    fetch('/api/admin/redes-sociales')
+    fetch('/api/redes-sociales')
       .then(res => res.json())
-      .then(data => setRedes(data.filter((r: RedSocial) => r.activo)))
+      .then(json => {
+        const data = json?.success ? json.data : json
+        setRedes(data.filter((r: RedSocial) => r.activo))
+      })
       .catch(console.error)
 
     // Cargar configuración
-    fetch('/api/admin/configuracion')
+    fetch('/api/configuracion')
       .then(res => res.json())
-      .then(data => {
+      .then(json => {
+        const payload = json?.success ? json.data : json
         const configObj: Record<string, string> = {}
-        data.forEach((item: any) => {
-          configObj[item.clave] = item.valor
-        })
+        if (Array.isArray(payload)) {
+          payload.forEach((item: any) => {
+            configObj[item.clave] = item.valor
+          })
+        } else if (payload && typeof payload === 'object') {
+          Object.entries(payload).forEach(([k, v]) => {
+            configObj[k] = String(v)
+          })
+        }
         setConfig(prev => ({ ...prev, ...configObj }))
       })
       .catch(console.error)

--- a/src/features/landing/NewHero.tsx
+++ b/src/features/landing/NewHero.tsx
@@ -17,7 +17,7 @@ export function NewHero() {
 
   useEffect(() => {
     // Cargar configuración del sitio (tolera {success,data} u arreglo legacy)
-    fetch('/api/admin/configuracion')
+    fetch('/api/configuracion')
       .then(res => res.json())
       .then((json) => {
         const payload: any = json?.success ? json.data : json

--- a/src/features/landing/PaymentMethods.tsx
+++ b/src/features/landing/PaymentMethods.tsx
@@ -16,9 +16,12 @@ export function PaymentMethods() {
   const [selectedMethod, setSelectedMethod] = useState<string>('')
 
   useEffect(() => {
-    fetch('/api/admin/metodos-pago')
+    fetch('/api/metodos-pago')
       .then(res => res.json())
-      .then(data => setMetodos(data.filter((m: MetodoPago) => m.activo)))
+      .then(json => {
+        const data = json?.success ? json.data : json
+        setMetodos(data.filter((m: MetodoPago) => m.activo))
+      })
       .catch(console.error)
   }, [])
 

--- a/src/features/landing/SocialLinks.tsx
+++ b/src/features/landing/SocialLinks.tsx
@@ -14,9 +14,12 @@ export function SocialLinks() {
   const [redes, setRedes] = useState<RedSocial[]>([])
 
   useEffect(() => {
-    fetch('/api/admin/redes-sociales')
+    fetch('/api/redes-sociales')
       .then(res => res.json())
-      .then(data => setRedes(data.filter((r: RedSocial) => r.activo)))
+      .then(json => {
+        const data = json?.success ? json.data : json
+        setRedes(data.filter((r: RedSocial) => r.activo))
+      })
       .catch(console.error)
   }, [])
 


### PR DESCRIPTION
## Summary
- add public `/api/configuracion`, `/api/metodos-pago` and `/api/redes-sociales` GET endpoints
- enforce auth on admin counterparts and delegate reads to public routes
- update landing and purchase code to consume the new public APIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a298f31f0c8320b948e03fb5d5597b