### PR TITLE
feat: add shared api client

### DIFF
--- a/src/features/admin/analytics/SalesChart.tsx
+++ b/src/features/admin/analytics/SalesChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { get } from '@/lib/api-client'
 
 interface Point {
   fecha: string
@@ -11,11 +12,9 @@ export function SalesChart() {
   const [data, setData] = useState<Point[]>([])
 
   useEffect(() => {
-    fetch('/api/admin/analytics/ventas')
-      .then(res => res.json())
-      .then(res => {
-        if (res.success) setData(res.data)
-      })
+    get('/api/admin/analytics/ventas').then(res => {
+      if (res.success) setData(res.data)
+    })
   }, [])
 
   const max = Math.max(...data.map(d => d.monto), 0)

--- a/src/features/admin/configuracion/page.tsx
+++ b/src/features/admin/configuracion/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { formatCurrencyFlexible } from '@/lib/utils'
+import { get, put, post } from '@/lib/api-client'
 
 interface ConfiguracionSitio {
   id: string
@@ -25,8 +26,7 @@ export default function ConfiguracionPage() {
 
   const cargarConfiguracion = async () => {
     try {
-      const response = await fetch('/api/admin/configuracion')
-      const json = await response.json()
+      const json = await get('/api/admin/configuracion')
       const payload: any = json?.success ? json.data : json
 
       if (Array.isArray(payload)) {
@@ -61,11 +61,7 @@ export default function ConfiguracionPage() {
   const guardarConfiguracion = async () => {
     setSaving(true)
     try {
-      await fetch('/api/admin/configuracion', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ configuraciones: editedConfig })
-      })
+      await put('/api/admin/configuracion', { configuraciones: editedConfig })
 
       alert('Configuración guardada exitosamente')
       cargarConfiguracion()
@@ -81,8 +77,7 @@ export default function ConfiguracionPage() {
     try {
       const fd = new FormData()
       fd.append('file', file)
-      const res = await fetch('/api/upload', { method: 'POST', body: fd })
-      const json = await res.json()
+      const json = await post('/api/upload', fd)
       if (json?.success && json?.url) {
         handleChange('logo_url', json.url)
         alert('Logo subido correctamente')

--- a/src/features/admin/login/page.tsx
+++ b/src/features/admin/login/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/Button'
 import { AlertCircle, Shield, Eye, EyeOff } from 'lucide-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { get, post } from '@/lib/api-client'
 
 interface LoginForm {
   email: string
@@ -45,12 +46,9 @@ function LoginContent() {
   useEffect(() => {
     const checkAuthStatus = async () => {
       try {
-        const response = await fetch('/api/auth/me')
-        if (response.ok) {
-          const data = await response.json()
-          if (data.success && ['ADMIN', 'SUPER_ADMIN'].includes(data.user.rol)) {
-            router.push(redirectTo)
-          }
+        const data = await get('/api/auth/me')
+        if (data.success && ['ADMIN', 'SUPER_ADMIN'].includes(data.user.rol)) {
+          router.push(redirectTo)
         }
       } catch (error) {
         // Usuario no autenticado - continuar en login
@@ -75,15 +73,7 @@ function LoginContent() {
     setError(null)
 
     try {
-      const response = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      })
-
-      const data: LoginResponse = await response.json()
+      const data: LoginResponse = await post('/api/auth/login', formData)
 
       if (data.success) {
         // Verificar que el usuario sea administrador

--- a/src/features/admin/metodos-pago/page.tsx
+++ b/src/features/admin/metodos-pago/page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { get, post, put, del } from '@/lib/api-client'
 
 interface MetodoPago {
   id: string
@@ -27,8 +28,7 @@ export default function MetodosPagoPage() {
 
   const cargarMetodos = async () => {
     try {
-      const response = await fetch('/api/admin/metodos-pago')
-      const data = await response.json()
+      const data = await get('/api/admin/metodos-pago')
       setMetodos(data)
     } catch (error) {
       console.error('Error cargando métodos de pago:', error)
@@ -57,20 +57,17 @@ export default function MetodosPagoPage() {
     if (!editingMethod) return
 
     try {
-      const method = isCreating ? 'POST' : 'PUT'
       const url = '/api/admin/metodos-pago'
-      
-      const response = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(editingMethod)
-      })
 
-      if (response.ok) {
-        alert(isCreating ? 'Método creado exitosamente' : 'Método actualizado exitosamente')
-        setEditingMethod(null)
-        cargarMetodos()
+      if (isCreating) {
+        await post(url, editingMethod)
+      } else {
+        await put(url, editingMethod)
       }
+
+      alert(isCreating ? 'Método creado exitosamente' : 'Método actualizado exitosamente')
+      setEditingMethod(null)
+      cargarMetodos()
     } catch (error) {
       console.error('Error guardando método:', error)
       alert('Error guardando método')
@@ -79,11 +76,7 @@ export default function MetodosPagoPage() {
 
   const toggleActivo = async (id: string, activo: boolean) => {
     try {
-      await fetch('/api/admin/metodos-pago', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, activo })
-      })
+      await put('/api/admin/metodos-pago', { id, activo })
       cargarMetodos()
     } catch (error) {
       console.error('Error actualizando estado:', error)
@@ -94,9 +87,7 @@ export default function MetodosPagoPage() {
     if (!confirm('¿Estás seguro de eliminar este método de pago?')) return
 
     try {
-      await fetch(`/api/admin/metodos-pago?id=${id}`, {
-        method: 'DELETE'
-      })
+      await del(`/api/admin/metodos-pago?id=${id}`)
       alert('Método eliminado exitosamente')
       cargarMetodos()
     } catch (error) {

--- a/src/features/admin/notifications/AdminNotificationCenter.tsx
+++ b/src/features/admin/notifications/AdminNotificationCenter.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
+import { get, patch } from '@/lib/api-client'
 
 interface Notification {
   id: string
@@ -18,8 +19,7 @@ export function AdminNotificationCenter() {
   const [search, setSearch] = useState('')
 
   useEffect(() => {
-    fetch('/api/admin/notificaciones?limit=50')
-      .then(res => res.json())
+    get('/api/admin/notificaciones?limit=50')
       .then(data => {
         if (data.success) {
           setNotifications(data.data || [])
@@ -49,11 +49,7 @@ export function AdminNotificationCenter() {
   })
 
   const markAllRead = async () => {
-    await fetch('/api/admin/notificaciones', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ adminId: 'admin-demo' })
-    })
+    await patch('/api/admin/notificaciones', { adminId: 'admin-demo' })
     setNotifications(prev => prev.map(n => ({ ...n, leida: true })))
   }
 

--- a/src/features/admin/pagos/page.tsx
+++ b/src/features/admin/pagos/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { get } from '@/lib/api-client'
 import { 
   Search,
   Filter,
@@ -44,11 +45,7 @@ export default function PagosPage() {
   useEffect(() => {
     const fetchPagos = async () => {
       try {
-        const res = await fetch('/api/admin/verificar-pagos', { cache: 'no-store' })
-        if (!res.ok) {
-          throw new Error('Error al cargar pagos')
-        }
-        const json = await res.json()
+        const json = await get('/api/admin/verificar-pagos', { cache: 'no-store' })
         const mapped = (json.data || []).map((p: any) => ({
           id: p.id,
           participante: {

--- a/src/features/admin/participantes/page.tsx
+++ b/src/features/admin/participantes/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { get } from '@/lib/api-client'
 import { 
   Search,
   Filter,
@@ -41,11 +42,7 @@ export default function ParticipantesPage() {
   useEffect(() => {
     const fetchParticipantes = async () => {
       try {
-        const res = await fetch('/api/admin/participantes', { cache: 'no-store' })
-        if (!res.ok) {
-          throw new Error('Error al cargar participantes')
-        }
-        const data = await res.json()
+        const data = await get('/api/admin/participantes', { cache: 'no-store' })
         setParticipantes(data.data || [])
       } catch (err: any) {
         setError(err.message || 'Error desconocido')

--- a/src/features/admin/redes-sociales/page.tsx
+++ b/src/features/admin/redes-sociales/page.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { get, post, put, del } from '@/lib/api-client'
 
 interface RedSocial {
   id: string
@@ -26,8 +27,7 @@ export default function RedesSocialesPage() {
 
   const cargarRedes = async () => {
     try {
-      const response = await fetch('/api/admin/redes-sociales')
-      const data = await response.json()
+      const data = await get('/api/admin/redes-sociales')
       setRedes(data)
     } catch (error) {
       console.error('Error cargando redes sociales:', error)
@@ -55,20 +55,15 @@ export default function RedesSocialesPage() {
     if (!editingRed) return
 
     try {
-      const method = isCreating ? 'POST' : 'PUT'
       const url = '/api/admin/redes-sociales'
-      
-      const response = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(editingRed)
-      })
-
-      if (response.ok) {
-        alert(isCreating ? 'Red social creada exitosamente' : 'Red social actualizada exitosamente')
-        setEditingRed(null)
-        cargarRedes()
+      if (isCreating) {
+        await post(url, editingRed)
+      } else {
+        await put(url, editingRed)
       }
+      alert(isCreating ? 'Red social creada exitosamente' : 'Red social actualizada exitosamente')
+      setEditingRed(null)
+      cargarRedes()
     } catch (error) {
       console.error('Error guardando red social:', error)
       alert('Error guardando red social')
@@ -77,11 +72,7 @@ export default function RedesSocialesPage() {
 
   const toggleActivo = async (id: string, activo: boolean) => {
     try {
-      await fetch('/api/admin/redes-sociales', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, activo })
-      })
+      await put('/api/admin/redes-sociales', { id, activo })
       cargarRedes()
     } catch (error) {
       console.error('Error actualizando estado:', error)
@@ -92,9 +83,7 @@ export default function RedesSocialesPage() {
     if (!confirm('¿Estás seguro de eliminar esta red social?')) return
 
     try {
-      await fetch(`/api/admin/redes-sociales?id=${id}`, {
-        method: 'DELETE'
-      })
+      await del(`/api/admin/redes-sociales?id=${id}`)
       alert('Red social eliminada exitosamente')
       cargarRedes()
     } catch (error) {

--- a/src/features/admin/usuarios/page.tsx
+++ b/src/features/admin/usuarios/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { get } from '@/lib/api-client'
 import { 
   Plus,
   Search,
@@ -39,11 +40,7 @@ export default function UsuariosPage() {
   useEffect(() => {
     const fetchUsuarios = async () => {
       try {
-        const res = await fetch('/api/admin/usuarios', { cache: 'no-store' })
-        if (!res.ok) {
-          throw new Error('Error al cargar usuarios')
-        }
-        const data = await res.json()
+        const data = await get('/api/admin/usuarios', { cache: 'no-store' })
         setUsuarios(data.data || [])
       } catch (err: any) {
         setError(err.message || 'Error desconocido')

--- a/src/features/landing/CompraRifa.tsx
+++ b/src/features/landing/CompraRifa.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { formatCurrencyFlexible } from '@/lib/utils'
+import { get, post } from '@/lib/api-client'
 
 interface Rifa {
   id: string
@@ -85,8 +86,7 @@ export function CompraRifa() {
   useEffect(() => {
     const cargarRifas = async () => {
       try {
-        const response = await fetch('/api/rifas')
-        const data = await response.json()
+        const data = await get('/api/rifas')
         if (data.success) {
           setRifas(data.data)
           if (data.data.length > 0) {
@@ -101,8 +101,7 @@ export function CompraRifa() {
 
     const cargarMetodosPago = async () => {
       try {
-        const response = await fetch('/api/metodos-pago')
-        const json = await response.json()
+        const json = await get('/api/metodos-pago')
         const data = json?.success ? json.data : json
         setMetodosPago(data)
       } catch (error) {
@@ -119,8 +118,7 @@ export function CompraRifa() {
   useEffect(() => {
     const loadSiteConfig = async () => {
       try {
-        const res = await fetch('/api/configuracion')
-        const json = await res.json()
+        const json = await get('/api/configuracion')
         const payload = json?.success ? json.data : json
         const map: Record<string, string> = {}
         if (Array.isArray(payload)) {
@@ -148,8 +146,7 @@ export function CompraRifa() {
     const loadTop = async () => {
       if (!rifaSeleccionada) return
       try {
-        const res = await fetch(`/api/rifas/${rifaSeleccionada.id}/top-compradores`)
-        const data = await res.json()
+        const data = await get(`/api/rifas/${rifaSeleccionada.id}/top-compradores`)
         if (data?.success) setTopCompradores(data.data)
       } catch {}
     }
@@ -203,8 +200,7 @@ export function CompraRifa() {
     if (rifaSeleccionada) {
       const cargarTickets = async () => {
         try {
-          const response = await fetch(`/api/rifas/${rifaSeleccionada.id}/tickets`)
-          const data = await response.json()
+          const data = await get(`/api/rifas/${rifaSeleccionada.id}/tickets`)
           if (data.success) {
             setTickets(data.tickets)
           }
@@ -334,12 +330,7 @@ export function CompraRifa() {
       const formData = new FormData()
       formData.append('file', file)
 
-      const response = await fetch('/api/upload', {
-        method: 'POST',
-        body: formData,
-      })
-
-      const result = await response.json()
+      const result = await post('/api/upload', formData)
       
       if (result.success) {
         return result.url
@@ -399,15 +390,7 @@ export function CompraRifa() {
         }
       }
 
-      const response = await fetch('/api/compras', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(compraData)
-      })
-
-      const result = await response.json()
+      const result = await post('/api/compras', compraData)
 
       if (result.success) {
         alert(`¡Compra reservada! Referencia: ${result.detalles.referencia}`)
@@ -421,8 +404,7 @@ export function CompraRifa() {
         setImagenComprobante(null)
         setPreviewImagen(null)
         // Recargar tickets
-        const ticketsResponse = await fetch(`/api/rifas/${rifaSeleccionada.id}/tickets`)
-        const ticketsData = await ticketsResponse.json()
+        const ticketsData = await get(`/api/rifas/${rifaSeleccionada.id}/tickets`)
         if (ticketsData.success) {
           setTickets(ticketsData.tickets)
         }

--- a/src/features/landing/FloatingSupportButtons.tsx
+++ b/src/features/landing/FloatingSupportButtons.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { TicketVerifier } from '@/features/landing/TicketVerifier'
+import { get } from '@/lib/api-client'
 
 type SiteConfig = Record<string, any>
 
@@ -67,8 +68,7 @@ export function FloatingSupportButtons() {
   const [config, setConfig] = useState<SiteConfig>({})
 
   useEffect(() => {
-    fetch('/api/configuracion')
-      .then(async (res) => res.json())
+    get('/api/configuracion')
       .then((json) => {
         // Tolerar ambas formas: {success, data} o lista/objeto directo
         const maybe = (json?.success ? json.data : json) as any

--- a/src/features/landing/NewFooter.tsx
+++ b/src/features/landing/NewFooter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { get } from '@/lib/api-client'
 
 interface RedSocial {
   id: string
@@ -20,8 +21,7 @@ export function NewFooter() {
 
   useEffect(() => {
     // Cargar redes sociales
-    fetch('/api/redes-sociales')
-      .then(res => res.json())
+    get('/api/redes-sociales')
       .then(json => {
         const data = json?.success ? json.data : json
         setRedes(data.filter((r: RedSocial) => r.activo))
@@ -29,8 +29,7 @@ export function NewFooter() {
       .catch(console.error)
 
     // Cargar configuración
-    fetch('/api/configuracion')
-      .then(res => res.json())
+    get('/api/configuracion')
       .then(json => {
         const payload = json?.success ? json.data : json
         const configObj: Record<string, string> = {}

--- a/src/features/landing/NewHero.tsx
+++ b/src/features/landing/NewHero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { get } from '@/lib/api-client'
 
 interface ConfiguracionSitio {
   id: string
@@ -17,8 +18,7 @@ export function NewHero() {
 
   useEffect(() => {
     // Cargar configuración del sitio (tolera {success,data} u arreglo legacy)
-    fetch('/api/configuracion')
-      .then(res => res.json())
+    get('/api/configuracion')
       .then((json) => {
         const payload: any = json?.success ? json.data : json
         const configObj: Record<string, string> = {}

--- a/src/features/landing/PaymentMethods.tsx
+++ b/src/features/landing/PaymentMethods.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { get } from '@/lib/api-client'
 
 interface MetodoPago {
   id: string
@@ -16,8 +17,7 @@ export function PaymentMethods() {
   const [selectedMethod, setSelectedMethod] = useState<string>('')
 
   useEffect(() => {
-    fetch('/api/metodos-pago')
-      .then(res => res.json())
+    get('/api/metodos-pago')
       .then(json => {
         const data = json?.success ? json.data : json
         setMetodos(data.filter((m: MetodoPago) => m.activo))

--- a/src/features/landing/SocialLinks.tsx
+++ b/src/features/landing/SocialLinks.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { get } from '@/lib/api-client'
 
 interface RedSocial {
   id: string
@@ -14,8 +15,7 @@ export function SocialLinks() {
   const [redes, setRedes] = useState<RedSocial[]>([])
 
   useEffect(() => {
-    fetch('/api/redes-sociales')
-      .then(res => res.json())
+    get('/api/redes-sociales')
       .then(json => {
         const data = json?.success ? json.data : json
         setRedes(data.filter((r: RedSocial) => r.activo))

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,57 @@
+import { CONFIG } from './config'
+
+const BASE_URL = CONFIG.ENDPOINTS.BASE_URL
+
+function buildUrl(path: string) {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path
+  }
+  return `${BASE_URL}${path}`
+}
+
+async function request<T>(method: string, path: string, body?: any, options: RequestInit = {}): Promise<T> {
+  const url = buildUrl(path)
+  const headers: HeadersInit = { ...(options.headers || {}) }
+  let payload: BodyInit | undefined = undefined
+
+  if (body instanceof FormData) {
+    payload = body
+  } else if (body !== undefined && body !== null) {
+    headers['Content-Type'] = 'application/json'
+    payload = JSON.stringify(body)
+  }
+
+  try {
+    const res = await fetch(url, { ...options, method, headers, body: payload })
+
+    if (!res.ok) {
+      let message = res.statusText
+      try {
+        const errorData = await res.json()
+        message = errorData.message || errorData.error || message
+      } catch {}
+      throw new Error(message)
+    }
+
+    if (res.status === 204) {
+      return undefined as unknown as T
+    }
+
+    const contentType = res.headers.get('content-type')
+    if (contentType && contentType.includes('application/json')) {
+      return (await res.json()) as T
+    }
+    return (await res.text()) as unknown as T
+  } catch (err) {
+    console.error('API request error:', err)
+    throw err
+  }
+}
+
+export const get = <T>(path: string, options?: RequestInit) => request<T>('GET', path, undefined, options)
+export const post = <T>(path: string, body?: any, options?: RequestInit) => request<T>('POST', path, body, options)
+export const put = <T>(path: string, body?: any, options?: RequestInit) => request<T>('PUT', path, body, options)
+export const patch = <T>(path: string, body?: any, options?: RequestInit) => request<T>('PATCH', path, body, options)
+export const del = <T>(path: string, options?: RequestInit) => request<T>('DELETE', path, undefined, options)
+
+export default { get, post, put, patch, del }


### PR DESCRIPTION
## Summary
- add reusable api client with unified error handling
- replace direct fetch usage in public and admin components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)

------
https://chatgpt.com/codex/tasks/task_b_68a2a871b2248320855996a1b5dce611