### PR TITLE
feat: enable prisma logging only in development

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,7 +7,7 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: ['query'],
+    log: process.env.NODE_ENV === 'development' ? ['query'] : undefined,
   })
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- enable Prisma logging only when `NODE_ENV` is `development`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2a9efadbc832093f33b6ec919e9b3