### PR TITLE
feat: add ticket stats endpoint and dynamic landing stats

### DIFF
--- a/src/app/api/rifas/[id]/stats/route.ts
+++ b/src/app/api/rifas/[id]/stats/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params
+
+    // Verificar que la rifa existe y está activa
+    const rifa = await prisma.rifa.findFirst({
+      where: { id, estado: 'ACTIVA' }
+    })
+
+    if (!rifa) {
+      return NextResponse.json(
+        { success: false, error: 'Rifa no encontrada o no activa' },
+        { status: 404 }
+      )
+    }
+
+    const [disponibles, vendidos, reservados, total] = await Promise.all([
+      prisma.ticket.count({ where: { rifaId: id, estado: 'DISPONIBLE' } }),
+      prisma.ticket.count({
+        where: {
+          rifaId: id,
+          estado: { in: ['VENDIDO', 'PAGADO'] }
+        }
+      }),
+      prisma.ticket.count({
+        where: {
+          rifaId: id,
+          estado: { in: ['RESERVADO', 'EN_VERIFICACION'] }
+        }
+      }),
+      prisma.ticket.count({ where: { rifaId: id } })
+    ])
+
+    return NextResponse.json({
+      success: true,
+      data: { disponibles, vendidos, reservados, total }
+    })
+  } catch (error) {
+    console.error('Error obteniendo contadores de tickets:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error interno del servidor' },
+      { status: 500 }
+    )
+  }
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to report ticket availability per raffle
- pull ticket counts into landing page and compute progress bar

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2bbb1bc9c8320b2b3b746a0c0d58c