### PR TITLE
Integrate PayPal payments with webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ SMS_ACCOUNT_SID="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 SMS_AUTH_TOKEN="your_auth_token"
 SMS_FROM="+1234567890"
 
+# PayPal API credentials
+PAYPAL_CLIENT_ID=""
+PAYPAL_CLIENT_SECRET=""
+PAYPAL_ENV="sandbox" # o "live"
+
 # Contacto de administradores
 ADMIN_EMAIL="admin@example.com"
 ADMIN_PHONE="+1234567890"

--- a/.env.production.example
+++ b/.env.production.example
@@ -26,6 +26,9 @@ FROM_EMAIL="rifas@tudominio.com"
 # Pagos (configurar cuando se implemente)
 # MERCADOPAGO_ACCESS_TOKEN=""
 # MERCADOPAGO_PUBLIC_KEY=""
+# PAYPAL_CLIENT_ID=""
+# PAYPAL_CLIENT_SECRET=""
+# PAYPAL_ENV="live" # o "sandbox"
 
 # Configuración de seguridad
 COOKIE_SECURE="true"

--- a/prisma/migrations/202508180600_add_payment_id/migration.sql
+++ b/prisma/migrations/202508180600_add_payment_id/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "compras" ADD COLUMN "paymentId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,7 @@ model Compra {
   imagenComprobante String?    // URL de la imagen del comprobante
   bancoId         String?
   referencia      String?
+  paymentId       String?
   fechaVencimiento DateTime?
   
   createdAt       DateTime     @default(now())

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { getOrder } from '@/lib/paypal'
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const paymentId = body?.resource?.id || body?.id
+    if (!paymentId) {
+      return NextResponse.json({ error: 'paymentId no proporcionado' }, { status: 400 })
+    }
+
+    try {
+      const order = await getOrder(paymentId)
+      if (order?.status === 'COMPLETED') {
+        await prisma.compra.updateMany({
+          where: { paymentId },
+          data: { estadoPago: 'PAGADO' }
+        })
+      }
+    } catch (err) {
+      console.error('Error verificando orden PayPal:', err)
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('Error en webhook de pagos:', err)
+    return NextResponse.json({ error: 'Error interno del servidor' }, { status: 500 })
+  }
+}

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -1,0 +1,70 @@
+import axios from 'axios'
+
+const PAYPAL_API = process.env.PAYPAL_ENV === 'live'
+  ? 'https://api-m.paypal.com'
+  : 'https://api-m.sandbox.paypal.com'
+
+async function getAccessToken() {
+  const clientId = process.env.PAYPAL_CLIENT_ID
+  const clientSecret = process.env.PAYPAL_CLIENT_SECRET
+  if (!clientId || !clientSecret) {
+    throw new Error('Faltan credenciales de PayPal')
+  }
+  const auth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+  const params = new URLSearchParams()
+  params.append('grant_type', 'client_credentials')
+
+  const response = await axios.post(
+    `${PAYPAL_API}/v1/oauth2/token`,
+    params.toString(),
+    {
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    }
+  )
+  return response.data.access_token as string
+}
+
+export async function createOrder(total: number) {
+  const token = await getAccessToken()
+  const response = await axios.post(
+    `${PAYPAL_API}/v2/checkout/orders`,
+    {
+      intent: 'CAPTURE',
+      purchase_units: [
+        {
+          amount: {
+            currency_code: 'USD',
+            value: total.toFixed(2)
+          }
+        }
+      ]
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+
+  const { id, links } = response.data
+  const approvalLink = links?.find((l: any) => l.rel === 'approve')?.href
+  return { id, approvalLink }
+}
+
+export async function getOrder(orderId: string) {
+  const token = await getAccessToken()
+  const response = await axios.get(
+    `${PAYPAL_API}/v2/checkout/orders/${orderId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+  return response.data
+}


### PR DESCRIPTION
## Summary
- add PayPal REST helper and payment webhook
- extend purchases API to create PayPal order links and save paymentId
- introduce `paymentId` column and env variables for PayPal credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/lib/paypal.ts src/app/api/compras/route.ts src/app/api/payments/webhook/route.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a2c0bc6aa48320ae96e812506648dd