### PR TITLE
feat: store PayPal and SMTP credentials in site configuration

### DIFF
--- a/src/app/api/admin/configuracion/route.ts
+++ b/src/app/api/admin/configuracion/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthUser } from '@/lib/auth'
-import { GET as publicGet } from '../../configuracion/route'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
@@ -11,8 +10,32 @@ export async function GET() {
       { status: 403 }
     )
   }
+  try {
+    const configuraciones = await prisma.configuracionSitio.findMany({
+      orderBy: { clave: 'asc' }
+    })
 
-  return publicGet()
+    const config = configuraciones.reduce((acc, item) => {
+      try {
+        if (item.tipo === 'json') {
+          acc[item.clave] = JSON.parse(item.valor)
+        } else {
+          acc[item.clave] = item.valor
+        }
+      } catch {
+        acc[item.clave] = item.valor
+      }
+      return acc
+    }, {} as Record<string, any>)
+
+    return NextResponse.json({ success: true, data: config })
+  } catch (error) {
+    console.error('Error obteniendo configuraciones:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error obteniendo configuraciones' },
+      { status: 500 }
+    )
+  }
 }
 
 export async function PUT(request: NextRequest) {

--- a/src/app/api/configuracion/route.ts
+++ b/src/app/api/configuracion/route.ts
@@ -20,6 +20,19 @@ export async function GET() {
       return acc
     }, {} as Record<string, any>)
 
+    const SENSITIVE_KEYS = [
+      'PAYPAL_CLIENT_ID',
+      'PAYPAL_CLIENT_SECRET',
+      'SMTP_HOST',
+      'SMTP_PORT',
+      'SMTP_USER',
+      'SMTP_PASSWORD',
+    ]
+
+    for (const key of SENSITIVE_KEYS) {
+      delete (config as any)[key]
+    }
+
     return NextResponse.json({ success: true, data: config })
   } catch (error) {
     console.error('Error obteniendo configuraciones:', error)

--- a/src/features/admin/configuracion/page.tsx
+++ b/src/features/admin/configuracion/page.tsx
@@ -131,6 +131,15 @@ export default function ConfiguracionPage() {
     ] },
   ]
 
+  const configuracionesIntegraciones = [
+    { clave: 'PAYPAL_CLIENT_ID', nombre: 'PayPal Client ID', tipo: 'text' },
+    { clave: 'PAYPAL_CLIENT_SECRET', nombre: 'PayPal Client Secret', tipo: 'password' },
+    { clave: 'SMTP_HOST', nombre: 'SMTP Host', tipo: 'text' },
+    { clave: 'SMTP_PORT', nombre: 'SMTP Port', tipo: 'number' },
+    { clave: 'SMTP_USER', nombre: 'SMTP User', tipo: 'text' },
+    { clave: 'SMTP_PASSWORD', nombre: 'SMTP Password', tipo: 'password' },
+  ]
+
   const renderConfigSection = (titulo: string, configs: any[]) => (
     <div className="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
       <div className="bg-gradient-to-r from-blue-600 to-purple-600 px-6 py-4">
@@ -251,9 +260,10 @@ export default function ConfiguracionPage() {
 
   {/* Secciones de configuración */}
         {renderConfigSection('🎨 Configuración General', configuracionesGenerales)}
-  {renderConfigSection('💵 Moneda y precios', configuracionesMoneda)}
-  {renderConfigSection('📞 Información de Contacto', configuracionesContacto)}
-  {renderConfigSection('❓ Botón de Ayuda (contenido)', configuracionesAyuda)}
+        {renderConfigSection('💵 Moneda y precios', configuracionesMoneda)}
+        {renderConfigSection('🔑 Integraciones y credenciales', configuracionesIntegraciones)}
+        {renderConfigSection('📞 Información de Contacto', configuracionesContacto)}
+        {renderConfigSection('❓ Botón de Ayuda (contenido)', configuracionesAyuda)}
         {renderConfigSection('📋 Términos y Políticas', configuracionesTerminos)}
 
         {/* Panel de consejos */}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,3 +1,20 @@
+let DB_CONFIG: Record<string, string> = {}
+
+if (typeof window === 'undefined') {
+  try {
+    const { prisma } = await import('@/lib/prisma')
+    const dbConfigEntries = await prisma.configuracionSitio.findMany()
+    DB_CONFIG = dbConfigEntries.reduce((acc, item) => {
+      acc[item.clave] = item.valor
+      return acc
+    }, {} as Record<string, string>)
+  } catch {
+    DB_CONFIG = {}
+  }
+}
+
+const getConfigValue = (key: string) => DB_CONFIG[key] ?? process.env[key]
+
 // Configuración centralizada del sistema de rifas
 export const CONFIG = {
   // Configuración de tickets
@@ -109,13 +126,19 @@ export const CONFIG = {
 
   // Configuración de email
   EMAIL: {
-    SMTP_ENABLED: !!process.env.SMTP_HOST,
-    HOST: process.env.SMTP_HOST,
-    PORT: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587,
-    USER: process.env.SMTP_USER,
-    PASSWORD: process.env.SMTP_PASSWORD,
-    FROM_ADDRESS: process.env.FROM_EMAIL || 'noreply@rifas.com',
+    SMTP_ENABLED: !!getConfigValue('SMTP_HOST'),
+    HOST: getConfigValue('SMTP_HOST'),
+    PORT: getConfigValue('SMTP_PORT') ? parseInt(getConfigValue('SMTP_PORT') as string) : 587,
+    USER: getConfigValue('SMTP_USER'),
+    PASSWORD: getConfigValue('SMTP_PASSWORD'),
+    FROM_ADDRESS: getConfigValue('FROM_EMAIL') || 'noreply@rifas.com',
     TEMPLATES_PATH: '/templates/email',
+  },
+
+  PAYPAL: {
+    CLIENT_ID: getConfigValue('PAYPAL_CLIENT_ID'),
+    CLIENT_SECRET: getConfigValue('PAYPAL_CLIENT_SECRET'),
+    ENV: getConfigValue('PAYPAL_ENV') || 'sandbox',
   },
 
   // Configuración de SMS

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -1,12 +1,13 @@
 import axios from 'axios'
+import { CONFIG } from '@/lib/config'
 
-const PAYPAL_API = process.env.PAYPAL_ENV === 'live'
+const PAYPAL_API = CONFIG.PAYPAL.ENV === 'live'
   ? 'https://api-m.paypal.com'
   : 'https://api-m.sandbox.paypal.com'
 
 async function getAccessToken() {
-  const clientId = process.env.PAYPAL_CLIENT_ID
-  const clientSecret = process.env.PAYPAL_CLIENT_SECRET
+  const clientId = CONFIG.PAYPAL.CLIENT_ID
+  const clientSecret = CONFIG.PAYPAL.CLIENT_SECRET
   if (!clientId || !clientSecret) {
     throw new Error('Faltan credenciales de PayPal')
   }


### PR DESCRIPTION
## Summary
- allow admins to edit PayPal and SMTP keys
- load PayPal/SMTP config from database with env fallback
- hide sensitive config from public API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a34f64edd08320af6a6ef586d77daa