### PR TITLE
Get current admin and use real ID for notifications

### DIFF
--- a/src/features/admin/notifications/AdminNotificationCenter.tsx
+++ b/src/features/admin/notifications/AdminNotificationCenter.tsx
@@ -17,6 +17,7 @@ export function AdminNotificationCenter() {
   const [notifications, setNotifications] = useState<Notification[]>([])
   const [filter, setFilter] = useState<'all' | 'unread'>('all')
   const [search, setSearch] = useState('')
+  const [adminId, setAdminId] = useState<string | null>(null)
 
   useEffect(() => {
     get('/api/admin/notificaciones?limit=50')
@@ -41,6 +42,18 @@ export function AdminNotificationCenter() {
     return () => es.close()
   }, [])
 
+  useEffect(() => {
+    get('/api/auth/me')
+      .then(data => {
+        if (data.success) {
+          setAdminId(data.user.id)
+        }
+      })
+      .catch(err => {
+        console.error('Error fetching current user', err)
+      })
+  }, [])
+
   const filtered = notifications.filter(n => {
     if (filter === 'unread' && n.leida) return false
     if (search && !n.titulo.toLowerCase().includes(search.toLowerCase()) &&
@@ -49,7 +62,8 @@ export function AdminNotificationCenter() {
   })
 
   const markAllRead = async () => {
-    await patch('/api/admin/notificaciones', { adminId: 'admin-demo' })
+    if (!adminId) return
+    await patch('/api/admin/notificaciones', { adminId })
     setNotifications(prev => prev.map(n => ({ ...n, leida: true })))
   }
 


### PR DESCRIPTION
## Summary
- fetch current user in `AdminNotificationCenter` via `/api/auth/me`
- send authenticated admin ID when marking all notifications as read
- backend already reads admin ID from session token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3516a177c832097a3f76f3c9d2fb2