### PR TITLE
feat: add notification settings

### DIFF
--- a/src/app/admin/notificaciones/ajustes/page.tsx
+++ b/src/app/admin/notificaciones/ajustes/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '@/features/admin/notificaciones/ajustes/page'
+

--- a/src/app/api/admin/notificaciones/test-email/route.ts
+++ b/src/app/api/admin/notificaciones/test-email/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAuthUser } from '@/lib/auth'
+import { sendEmail } from '@/lib/sendEmail'
+
+export async function POST(request: NextRequest) {
+  const user = await getAuthUser()
+  if (!user || (user.rol !== 'ADMIN' && user.rol !== 'SUPER_ADMIN')) {
+    return NextResponse.json(
+      { success: false, error: 'No autorizado' },
+      { status: 403 }
+    )
+  }
+
+  try {
+    const { to } = await request.json()
+    const email = to || user.email
+    if (!email) {
+      return NextResponse.json(
+        { success: false, error: 'Email no disponible' },
+        { status: 400 }
+      )
+    }
+
+    await sendEmail(
+      email,
+      'Prueba de correo',
+      'La configuración de correo funciona correctamente.',
+      'SISTEMA'
+    )
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error enviando correo de prueba:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error enviando correo' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/features/admin/notificaciones/ajustes/page.tsx
+++ b/src/features/admin/notificaciones/ajustes/page.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { get, put, post } from '@/lib/api-client'
+import { CONFIG } from '@/lib/config'
+
+interface EmailTemplate { subject?: string; body?: string }
+interface SmsTemplate { body?: string }
+
+export default function NotificacionesAjustesPage() {
+  const tipos = CONFIG.NOTIFICACIONES.TIPOS_VALIDOS
+  const [smtpEnabled, setSmtpEnabled] = useState(false)
+  const [smsEnabled, setSmsEnabled] = useState(false)
+  const [emailTemplates, setEmailTemplates] = useState<Record<string, EmailTemplate>>({})
+  const [smsTemplates, setSmsTemplates] = useState<Record<string, SmsTemplate>>({})
+  const [saving, setSaving] = useState(false)
+  const [testEmail, setTestEmail] = useState('')
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const configResp = await get<any>('/api/admin/configuracion')
+        const data = configResp.data || configResp
+        setSmtpEnabled(data.SMTP_ENABLED === true || data.SMTP_ENABLED === 'true')
+        setSmsEnabled(data.SMS_ENABLED === true || data.SMS_ENABLED === 'true')
+        setEmailTemplates(data.EMAIL_TEMPLATES || {})
+        setSmsTemplates(data.SMS_TEMPLATES || {})
+      } catch (err) {
+        console.error('Error cargando configuración', err)
+      }
+      try {
+        const me = await get<any>('/api/auth/me')
+        if (me.success && me.user?.email) setTestEmail(me.user.email)
+      } catch {}
+    }
+    cargar()
+  }, [])
+
+  const handleEmailTemplate = (tipo: string, field: keyof EmailTemplate, value: string) => {
+    setEmailTemplates(prev => ({
+      ...prev,
+      [tipo]: { ...prev[tipo], [field]: value },
+    }))
+  }
+
+  const handleSmsTemplate = (tipo: string, value: string) => {
+    setSmsTemplates(prev => ({
+      ...prev,
+      [tipo]: { body: value },
+    }))
+  }
+
+  const guardar = async () => {
+    setSaving(true)
+    try {
+      await put('/api/admin/configuracion', {
+        configuraciones: {
+          SMTP_ENABLED: smtpEnabled,
+          SMS_ENABLED: smsEnabled,
+          EMAIL_TEMPLATES: emailTemplates,
+          SMS_TEMPLATES: smsTemplates,
+        },
+      })
+      alert('Configuración guardada')
+    } catch (e) {
+      console.error(e)
+      alert('Error guardando configuración')
+    }
+    setSaving(false)
+  }
+
+  const enviarPrueba = async () => {
+    try {
+      await post('/api/admin/notificaciones/test-email', { to: testEmail })
+      alert('Correo de prueba enviado')
+    } catch (e) {
+      console.error(e)
+      alert('Error enviando correo de prueba')
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-2xl font-bold">Ajustes de Notificaciones</h1>
+
+      <div className="space-y-4">
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={smtpEnabled}
+            onChange={(e) => setSmtpEnabled(e.target.checked)}
+          />
+          <span>SMTP habilitado</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={smsEnabled}
+            onChange={(e) => setSmsEnabled(e.target.checked)}
+          />
+          <span>SMS habilitado</span>
+        </label>
+      </div>
+
+      <div className="space-y-6">
+        {tipos.map((tipo) => (
+          <div key={tipo} className="border p-4 rounded-md space-y-2">
+            <h2 className="font-semibold">{tipo}</h2>
+            <Input
+              placeholder="Asunto email"
+              value={emailTemplates[tipo]?.subject || ''}
+              onChange={(e) => handleEmailTemplate(tipo, 'subject', e.target.value)}
+            />
+            <textarea
+              className="w-full border rounded-md p-2"
+              placeholder="Cuerpo email"
+              value={emailTemplates[tipo]?.body || ''}
+              onChange={(e) => handleEmailTemplate(tipo, 'body', e.target.value)}
+            />
+            <textarea
+              className="w-full border rounded-md p-2"
+              placeholder="Cuerpo SMS"
+              value={smsTemplates[tipo]?.body || ''}
+              onChange={(e) => handleSmsTemplate(tipo, e.target.value)}
+            />
+          </div>
+        ))}
+      </div>
+
+      <Button onClick={guardar} disabled={saving}>
+        {saving ? 'Guardando...' : 'Guardar'}
+      </Button>
+
+      <div className="space-y-2">
+        <Input
+          placeholder="Correo de prueba"
+          value={testEmail}
+          onChange={(e) => setTestEmail(e.target.value)}
+        />
+        <Button onClick={enviarPrueba}>Enviar correo de prueba</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -126,13 +126,24 @@ export const CONFIG = {
 
   // Configuración de email
   EMAIL: {
-    SMTP_ENABLED: !!getConfigValue('SMTP_HOST'),
+    SMTP_ENABLED:
+      getConfigValue('SMTP_ENABLED') !== undefined
+        ? getConfigValue('SMTP_ENABLED') === 'true'
+        : !!getConfigValue('SMTP_HOST'),
     HOST: getConfigValue('SMTP_HOST'),
     PORT: getConfigValue('SMTP_PORT') ? parseInt(getConfigValue('SMTP_PORT') as string) : 587,
     USER: getConfigValue('SMTP_USER'),
     PASSWORD: getConfigValue('SMTP_PASSWORD'),
     FROM_ADDRESS: getConfigValue('FROM_EMAIL') || 'noreply@rifas.com',
     TEMPLATES_PATH: '/templates/email',
+    TEMPLATES: (() => {
+      try {
+        const raw = getConfigValue('EMAIL_TEMPLATES')
+        return raw ? JSON.parse(raw) : {}
+      } catch {
+        return {}
+      }
+    })(),
   },
 
   PAYPAL: {
@@ -143,11 +154,22 @@ export const CONFIG = {
 
   // Configuración de SMS
   SMS: {
-    ENABLED: !!process.env.SMS_PROVIDER,
-    PROVIDER: process.env.SMS_PROVIDER || 'twilio',
-    ACCOUNT_SID: process.env.SMS_ACCOUNT_SID,
-    AUTH_TOKEN: process.env.SMS_AUTH_TOKEN,
-    FROM: process.env.SMS_FROM || 'Rifas',
+    ENABLED:
+      getConfigValue('SMS_ENABLED') !== undefined
+        ? getConfigValue('SMS_ENABLED') === 'true'
+        : !!process.env.SMS_PROVIDER,
+    PROVIDER: getConfigValue('SMS_PROVIDER') || process.env.SMS_PROVIDER || 'twilio',
+    ACCOUNT_SID: getConfigValue('SMS_ACCOUNT_SID') || process.env.SMS_ACCOUNT_SID,
+    AUTH_TOKEN: getConfigValue('SMS_AUTH_TOKEN') || process.env.SMS_AUTH_TOKEN,
+    FROM: getConfigValue('SMS_FROM') || process.env.SMS_FROM || 'Rifas',
+    TEMPLATES: (() => {
+      try {
+        const raw = getConfigValue('SMS_TEMPLATES')
+        return raw ? JSON.parse(raw) : {}
+      } catch {
+        return {}
+      }
+    })(),
   },
 
   // Contacto de administradores

--- a/src/lib/sendEmail.ts
+++ b/src/lib/sendEmail.ts
@@ -1,9 +1,22 @@
 import { CONFIG } from '@/lib/config'
 
-export async function sendEmail(to: string, subject: string, text: string) {
+export async function sendEmail(
+  to: string,
+  subject: string,
+  text: string,
+  type?: string
+) {
   if (!CONFIG.EMAIL.SMTP_ENABLED) {
     console.warn('SMTP no está configurado')
     return
+  }
+
+  if (type) {
+    const template = (CONFIG.EMAIL.TEMPLATES as Record<string, any>)[type]
+    if (template) {
+      subject = template.subject ?? subject
+      text = template.body ?? text
+    }
   }
 
   let nodemailer: any

--- a/src/lib/sendSMS.ts
+++ b/src/lib/sendSMS.ts
@@ -1,9 +1,16 @@
 import { CONFIG } from '@/lib/config'
 
-export async function sendSMS(to: string, body: string) {
+export async function sendSMS(to: string, body: string, type?: string) {
   if (!CONFIG.SMS.ENABLED) {
     console.warn('SMS no está configurado')
     return
+  }
+
+  if (type) {
+    const template = (CONFIG.SMS.TEMPLATES as Record<string, any>)[type]
+    if (template?.body) {
+      body = template.body
+    }
   }
 
   if (CONFIG.SMS.PROVIDER !== 'twilio') {


### PR DESCRIPTION
## Summary
- add admin notification settings page with SMTP/SMS toggles and template editor
- persist settings and allow sending test emails
- use stored templates in sendEmail and sendSMS helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a352d57bb08320a2e9ae75a02ab6a1