### PR TITLE
feat: add env utilities

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -3,7 +3,8 @@ import { stdin as input, stdout as output } from 'process'
 import { spawn } from 'child_process'
 import bcrypt from 'bcryptjs'
 import { PrismaClient } from '@prisma/client'
-import { testDatabaseConnection, generateSecret, writeEnv } from '../src/lib/setup'
+import { testDatabaseConnection } from '../src/lib/setup'
+import { generateSecret, writeEnvAtomic } from '../src/lib/env'
 
 const rl = readline.createInterface({ input, output })
 
@@ -50,7 +51,7 @@ async function main() {
   if (smtpUser) envVars.SMTP_USER = smtpUser
   if (smtpPassword) envVars.SMTP_PASSWORD = smtpPassword
 
-  await writeEnv(envVars)
+  await writeEnvAtomic(envVars)
   console.log('Archivo .env creado.')
 
   await new Promise<void>((resolve, reject) => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs'
+import { randomBytes } from 'crypto'
+
+export function generateSecret(length: number = 32): string {
+  return randomBytes(length).toString('hex')
+}
+
+export async function writeEnvAtomic(env: Record<string, string>): Promise<void> {
+  let content = ''
+  for (const [key, value] of Object.entries(env)) {
+    content += `${key}=${String(value)}\n`
+  }
+  if (!('FIRST_RUN' in env)) {
+    content += 'FIRST_RUN=false\n'
+  }
+
+  const tmpPath = '.env.tmp'
+  const finalPath = '.env'
+
+  const file = await fs.open(tmpPath, 'w', 0o600)
+  try {
+    await file.writeFile(content, 'utf8')
+    await file.sync()
+  } finally {
+    await file.close()
+  }
+
+  await fs.rename(tmpPath, finalPath)
+  await fs.chmod(finalPath, 0o600)
+}
+

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -1,6 +1,4 @@
 import { PrismaClient } from '@prisma/client'
-import { randomBytes } from 'crypto'
-import { atomicWrite } from './atomicWrite'
 
 export async function testDatabaseConnection(url: string) {
   const client = new PrismaClient({ datasourceUrl: url })
@@ -12,17 +10,3 @@ export async function testDatabaseConnection(url: string) {
   }
 }
 
-export function generateSecret() {
-  return randomBytes(32).toString('hex')
-}
-
-export async function writeEnv(vars: Record<string, string>) {
-  let content = ''
-  for (const [key, value] of Object.entries(vars)) {
-    content += `${key}=${String(value)}\n`
-  }
-  if (!('FIRST_RUN' in vars)) {
-    content += 'FIRST_RUN=false\n'
-  }
-  await atomicWrite('.env', content)
-}


### PR DESCRIPTION
## Summary
- add reusable generateSecret and writeEnvAtomic helpers
- switch setup API to new env utilities
- use env utilities in CLI setup script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-var-requires' was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a2ac96648320a160fbdef24582b7