### PR TITLE
Add admin eventos endpoint and update admin page

### DIFF
--- a/src/app/api/admin/eventos/route.ts
+++ b/src/app/api/admin/eventos/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { GET as getRifas } from '../../rifas/route'
+import { requireAuth, isAdmin } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const user = await requireAuth(request)
+  if (!user || !isAdmin(user)) {
+    return NextResponse.json(
+      { success: false, error: 'Acceso denegado' },
+      { status: 403 }
+    )
+  }
+
+  return getRifas(request)
+}


### PR DESCRIPTION
## Summary
- add admin eventos API endpoint reusing rifas logic
- fetch eventos from new endpoint in admin page with error/loading handling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_b_68a8ad8b85fc833183ba253cf7c21c0a