### PR TITLE
feat: add connectivity check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ NEXTAUTH_SECRET="otra-clave-segura-para-nextauth"
     - Revisa logs con `pm2 logs` si algo falla.
     - Los errores de la aplicación se guardan en `logs/errors.log`. Puedes revisarlos con `tail -f logs/errors.log`.
 
+11. **Comprobar rutas clave de la API**
+    ```bash
+    npm run check:conexion
+    ```
+    Genera un reporte de estado en `logs/conexion.log` para rutas como `/api/rifas` y `/api/admin/dashboard`.
+
 ## 🤝 Contribuir
 
 1. Haz fork del proyecto

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "db:switch-postgres": "node scripts/switch-db.js postgres",
     "db:status": "node scripts/switch-db.js status",
     "vps:setup": "powershell -ExecutionPolicy Bypass -File scripts/setup-vps.ps1",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "check:conexion": "tsx scripts/check-conexion.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/check-conexion.ts
+++ b/scripts/check-conexion.ts
@@ -1,0 +1,33 @@
+import { appendFile, mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+const routes = ['/api/rifas', '/api/admin/dashboard'];
+const baseUrl = process.env.CHECK_BASE_URL || 'http://localhost:3000';
+
+const logDir = path.join(process.cwd(), 'logs');
+const logFile = path.join(logDir, 'conexion.log');
+
+async function log(message: string) {
+  await appendFile(logFile, message + '\n');
+}
+
+async function checkRoute(route: string) {
+  const url = `${baseUrl}${route}`;
+  try {
+    const res = await fetch(url);
+    await log(`${new Date().toISOString()} ${route} ${res.status}`);
+  } catch (err) {
+    await log(`${new Date().toISOString()} ${route} ERROR ${(err as Error).message}`);
+  }
+}
+
+async function main() {
+  await mkdir(logDir, { recursive: true });
+  await writeFile(logFile, `\n=== Comprobación ${new Date().toISOString()} ===\n`, { flag: 'a' });
+  for (const route of routes) {
+    await checkRoute(route);
+  }
+  console.log(`Resultados guardados en ${logFile}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to test key API routes and log results
- expose npm run check:conexion command
- document how to run connectivity checks and where to find logs

## Testing
- `npm run check:conexion`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b1b9a58883318e333e36fa8a1fc3