### PR TITLE
refactor: make logger server-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ NEXTAUTH_SECRET="otra-clave-segura-para-nextauth"
     - Ingresa con el usuario administrador creado.
     - Revisa logs con `pm2 logs` si algo falla.
     - Los errores de la aplicación se guardan en `logs/errors.log`. Puedes revisarlos con `tail -f logs/errors.log`.
+    - En plataformas serverless el sistema de archivos suele ser efímero, por lo que estos registros pueden no persistir. Considera usar un servicio remoto de logging (por ejemplo, Logtail, Sentry) para almacenamiento duradero.
 
 11. **Comprobar rutas clave de la API**
     ```bash

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,4 @@
 import { CONFIG } from './config'
-import { logError } from './logger'
 
 const BASE_URL = CONFIG.ENDPOINTS.BASE_URL
 
@@ -44,7 +43,10 @@ async function request<T>(method: string, path: string, body?: any, options: Req
     }
     return (await res.text()) as unknown as T
   } catch (err) {
-    logError(`API request error: ${url}`, err)
+    if (typeof window === 'undefined') {
+      const { logError } = await import('./logger')
+      logError?.(`API request error: ${url}`, err)
+    }
     console.error('API request error:', err)
     throw err
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,26 +1,26 @@
-import fs from 'fs'
-import path from 'path'
+let logError: ((message: string, meta?: unknown) => Promise<void>) | undefined
 
-const logDir = path.join(process.cwd(), 'logs')
-const logFile = path.join(logDir, 'errors.log')
+if (typeof window === 'undefined') {
+  const path = await import('path')
+  const fs = await import('fs/promises')
 
-if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir, { recursive: true })
-}
+  const logDir = path.join(process.cwd(), 'logs')
+  const logFile = path.join(logDir, 'errors.log')
 
-export function logError(message: string, meta?: unknown) {
-  const timestamp = new Date().toISOString()
-  const metaString = meta ? ` ${JSON.stringify(meta)}` : ''
-  const entry = `[${timestamp}] ${message}${metaString}\n`
-
-  fs.appendFile(logFile, entry, err => {
-    if (err) {
+  logError = async (message: string, meta?: unknown) => {
+    const timestamp = new Date().toISOString()
+    const metaString = meta ? ` ${JSON.stringify(meta)}` : ''
+    const entry = `[${timestamp}] ${message}${metaString}\n`
+    try {
+      await fs.mkdir(logDir, { recursive: true })
+      await fs.appendFile(logFile, entry)
+    } catch (err) {
       console.error('Failed to write to log file', err)
     }
-  })
+  }
 }
 
-export default {
-  logError,
-}
+const logger = { logError }
 
+export { logError }
+export default logger


### PR DESCRIPTION
## Summary
- refactor logger to use fs/promises on server only
- avoid importing logger on client; log errors only server-side
- note serverless logging limitations and suggest remote services

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors in existing codebase)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b4c1e78c8331be0ad0ca46d657b5