### PR TITLE
feat: sanitize landing html

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test --import tsx",
     "maint:fix-admin-role": "tsx scripts/maintenance/fix-admin-role.ts",
     "maint:fix-admin-complete": "tsx scripts/maintenance/fix-admin-complete.ts",
     "maint:check-users": "tsx scripts/maintenance/check-users.ts",

--- a/src/features/landing/Description.tsx
+++ b/src/features/landing/Description.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { sanitizeHtml } from '@/lib/sanitize'
+
 interface DescriptionProps {
   descripcionHtml?: string
 }
@@ -115,19 +117,16 @@ export function Description({ descripcionHtml }: DescriptionProps) {
     </div>
   `
 
+  const html = descripcionHtml
+    ? sanitizeHtml(descripcionHtml)
+    : defaultDescription
+
   return (
     <div className="max-w-6xl mx-auto">
-      {descripcionHtml ? (
-        <div 
-          className="prose prose-lg max-w-none"
-          dangerouslySetInnerHTML={{ __html: descripcionHtml }}
-        />
-      ) : (
-        <div 
-          className="prose prose-lg max-w-none"
-          dangerouslySetInnerHTML={{ __html: defaultDescription }}
-        />
-      )}
+      <div
+        className="prose prose-lg max-w-none"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </div>
   )
 }

--- a/src/features/landing/FloatingSupportButtons.tsx
+++ b/src/features/landing/FloatingSupportButtons.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { TicketVerifier } from '@/features/landing/TicketVerifier'
 import { get } from '@/lib/api-client'
+import { sanitizeHtml } from '@/lib/sanitize'
 
 type SiteConfig = Record<string, any>
 
@@ -163,7 +164,9 @@ export function FloatingSupportButtons() {
           {config.ayuda_texto_html ? (
             <div
               className="prose prose-invert max-w-none"
-              dangerouslySetInnerHTML={{ __html: String(config.ayuda_texto_html) }}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(String(config.ayuda_texto_html)),
+              }}
             />
           ) : !config.ayuda_video_url ? (
             <div className="text-sm text-white/90 space-y-2">

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,7 @@
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/\s+on\w+\s*=\s*"[^"]*"/gi, '')
+    .replace(/\s+on\w+\s*=\s*'[^']*'/gi, '')
+    .replace(/javascript:/gi, '')
+}

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -1,0 +1,15 @@
+import { sanitizeHtml } from '../src/lib/sanitize'
+import test from 'node:test'
+import assert from 'node:assert'
+
+test('removes script tags', () => {
+  const dirty = '<p>hola</p><script>alert(1)</script>'
+  const clean = sanitizeHtml(dirty)
+  assert(!clean.includes('<script'))
+})
+
+test('removes dangerous attributes', () => {
+  const dirty = '<img src="x" onerror="alert(1)" />'
+  const clean = sanitizeHtml(dirty)
+  assert(!/onerror/i.test(clean))
+})


### PR DESCRIPTION
## Summary
- add simple HTML sanitizer and integrate into landing components
- add tests for stripping scripts and event handler attributes

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b7b2a3088331a59faab5657e6e0c