### PR TITLE
refactor: avoid console log on email

### DIFF
--- a/src/lib/sendEmail.ts
+++ b/src/lib/sendEmail.ts
@@ -1,4 +1,5 @@
 import { CONFIG } from '@/lib/config'
+import { logWarn } from '@/lib/logger'
 
 export async function sendEmail(
   to: string,
@@ -7,7 +8,7 @@ export async function sendEmail(
   type?: string
 ) {
   if (!CONFIG.EMAIL.SMTP_ENABLED) {
-    console.warn('SMTP no está configurado')
+    await logWarn?.('SMTP no está configurado')
     return
   }
 
@@ -24,8 +25,7 @@ export async function sendEmail(
     // Importación dinámica para evitar errores si la dependencia no está instalada
     nodemailer = (await eval('import("nodemailer")')).default
   } catch (error) {
-    console.warn('nodemailer no está instalado, no se envió el email')
-    console.log({ to, subject, text })
+    await logWarn?.('Email no enviado; nodemailer ausente', { type })
     return
   }
 

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+async function getFiles(dir: string): Promise<string[]> {
+  const dirents = await fs.readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const dirent of dirents) {
+    const res = path.join(dir, dirent.name)
+    if (dirent.isDirectory()) {
+      files.push(...(await getFiles(res)))
+    } else if (dirent.isFile() && /\.(ts|tsx|js)$/.test(dirent.name)) {
+      files.push(res)
+    }
+  }
+  return files
+}
+
+test('no console.log in production code', async () => {
+  const srcDir = path.join(process.cwd(), 'src')
+  const files = await getFiles(srcDir)
+  const offenders: string[] = []
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    if (/console\.log\(/.test(content)) {
+      offenders.push(path.relative(srcDir, file))
+    }
+  }
+  assert.strictEqual(offenders.length, 0, `console.log found in: ${offenders.join(', ')}`)
+})


### PR DESCRIPTION
## Summary
- use logger when nodemailer is missing
- add test to prevent console.log usage in src

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8b930e79083318ca60790648b1da1