### PR TITLE
feat(api-client): include cookies in fetch requests

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -11,7 +11,8 @@ function buildUrl(path: string) {
 
 async function request<T>(method: string, path: string, body?: any, options: RequestInit = {}): Promise<T> {
   const url = buildUrl(path)
-  const headers = new Headers(options.headers as HeadersInit)
+  const { credentials = 'include', headers: initHeaders, ...rest } = options
+  const headers = new Headers(initHeaders as HeadersInit)
   let payload: BodyInit | undefined = undefined
 
   if (body instanceof FormData) {
@@ -22,7 +23,13 @@ async function request<T>(method: string, path: string, body?: any, options: Req
   }
 
   try {
-  const res = await fetch(url, { ...options, method, headers, body: payload })
+    const res = await fetch(url, {
+      ...rest,
+      method,
+      headers,
+      body: payload,
+      credentials,
+    })
 
     if (!res.ok) {
       let message = res.statusText

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -46,35 +46,37 @@ let logError: ((message: string, meta?: unknown) => Promise<void>) | undefined
 let logWarn: ((message: string, meta?: unknown) => Promise<void>) | undefined
 
 if (typeof window === 'undefined') {
-  const path = await import('path')
-  const fs = await import('fs/promises')
+  ;(async () => {
+    const path = await import('path')
+    const fs = await import('fs/promises')
 
-  const logDir = path.join(process.cwd(), 'logs')
-  const logFile = path.join(logDir, 'errors.log')
+    const logDir = path.join(process.cwd(), 'logs')
+    const logFile = path.join(logDir, 'errors.log')
 
-  const writeLog = async (
-    level: LogLevel,
-    message: string,
-    meta?: unknown,
-  ) => {
-    if (!shouldLog(level)) return
-    const timestamp = new Date().toISOString()
-    const sanitized = meta ? sanitizeMeta(meta) : undefined
-    const metaString = sanitized ? ` ${JSON.stringify(sanitized)}` : ''
-    const entry = `[${timestamp}] [${level}] ${message}${metaString}\n`
-    try {
-      await fs.mkdir(logDir, { recursive: true })
-      await fs.appendFile(logFile, entry)
-    } catch (err) {
-      console.error('Failed to write to log file', err)
+    const writeLog = async (
+      level: LogLevel,
+      message: string,
+      meta?: unknown,
+    ) => {
+      if (!shouldLog(level)) return
+      const timestamp = new Date().toISOString()
+      const sanitized = meta ? sanitizeMeta(meta) : undefined
+      const metaString = sanitized ? ` ${JSON.stringify(sanitized)}` : ''
+      const entry = `[${timestamp}] [${level}] ${message}${metaString}\n`
+      try {
+        await fs.mkdir(logDir, { recursive: true })
+        await fs.appendFile(logFile, entry)
+      } catch (err) {
+        console.error('Failed to write to log file', err)
+      }
     }
-  }
 
-  logError = async (message: string, meta?: unknown) =>
-    writeLog('ERROR', message, meta)
+    logError = async (message: string, meta?: unknown) =>
+      writeLog('ERROR', message, meta)
 
-  logWarn = async (message: string, meta?: unknown) =>
-    writeLog('WARN', message, meta)
+    logWarn = async (message: string, meta?: unknown) =>
+      writeLog('WARN', message, meta)
+  })()
 }
 
 const logger = { logError, logWarn }

--- a/tests/api-client.test.ts
+++ b/tests/api-client.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { get } from '../src/lib/api-client'
+
+test('request includes credentials by default', async () => {
+  const originalFetch = global.fetch
+  let received: RequestInit | undefined
+  ;(global as any).fetch = async (_: RequestInfo, init?: RequestInit) => {
+    received = init
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    await get('/test')
+    assert.equal(received?.credentials, 'include')
+  } finally {
+    ;(global as any).fetch = originalFetch
+  }
+})
+
+test('request allows overriding credentials', async () => {
+  const originalFetch = global.fetch
+  let received: RequestInit | undefined
+  ;(global as any).fetch = async (_: RequestInfo, init?: RequestInit) => {
+    received = init
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    await get('/test', { credentials: 'omit' })
+    assert.equal(received?.credentials, 'omit')
+  } finally {
+    ;(global as any).fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Summary
- include credentials by default in api-client requests and allow overriding
- refactor logger init to avoid top-level await
- add unit tests for credentials handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8ba476e08833189ab13ea01cfc139