### PR TITLE
feat: load DB config at startup

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,5 +21,10 @@ const nextConfig = {
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
   },
 };
+require('tsx/cjs')
+const { initConfig } = require('./src/lib/config')
 
-module.exports = nextConfig;
+module.exports = async () => {
+  await initConfig()
+  return nextConfig
+};

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { initConfig, getConfigValue } from '../src/lib/config'
+
+// Ensure getConfigValue fetches values from DB and picks up updates
+
+void test('getConfigValue reads latest values from DB', async () => {
+  const results = [{ clave: 'SMTP_HOST', valor: 'smtp.initial.com' }]
+  const prismaMock = {
+    configuracionSitio: {
+      findMany: async () => results,
+    },
+  }
+
+  await initConfig(prismaMock)
+  const first = await getConfigValue('SMTP_HOST')
+  assert.equal(first, 'smtp.initial.com')
+
+  // simulate DB update and reload config
+  results[0].valor = 'smtp.updated.com'
+  await initConfig(prismaMock)
+  const second = await getConfigValue('SMTP_HOST')
+  assert.equal(second, 'smtp.updated.com')
+})


### PR DESCRIPTION
## Summary
- initialize configuration from the database before the Next.js server starts
- expose async `getConfigValue` that refreshes from DB when needed
- add regression test verifying config values are loaded from the database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8bb8b76f883318d760a0b351981fe