### PR TITLE
Show all payment methods in admin API and allow reactivation

### DIFF
--- a/src/app/api/admin/metodos-pago/route.ts
+++ b/src/app/api/admin/metodos-pago/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthUser } from '@/lib/auth'
-import { GET as publicGet } from '../../metodos-pago/route'
 import { prisma } from '@/lib/prisma'
 
 export async function GET() {
@@ -12,7 +11,19 @@ export async function GET() {
     )
   }
 
-  return publicGet()
+  try {
+    const metodos = await prisma.metodoPago.findMany({
+      orderBy: { orden: 'asc' }
+    })
+
+    return NextResponse.json({ success: true, data: metodos })
+  } catch (error) {
+    console.error('Error obteniendo métodos de pago:', error)
+    return NextResponse.json(
+      { success: false, error: 'Error obteniendo métodos de pago' },
+      { status: 500 }
+    )
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/src/features/admin/metodos-pago/page.tsx
+++ b/src/features/admin/metodos-pago/page.tsx
@@ -308,7 +308,7 @@ export default function MetodosPagoPage() {
                     onClick={() => toggleActivo(metodo.id, !metodo.activo)}
                     className={`text-xs px-2 py-1 rounded-md border backdrop-blur-sm ${metodo.activo ? 'bg-white/20 text-white border-white/20' : 'bg-slate-800/50 text-slate-300 border-slate-600/40'}`}
                   >
-                    {metodo.activo ? 'Activo' : 'Inactivo'}
+                    {metodo.activo ? 'Desactivar' : 'Reactivar'}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- return all payment methods from admin API ordered by `orden`
- update admin payment methods page to toggle inactive methods

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a9047efb208331bd713775986709d1