### PR TITLE
feat: allow optional estado filter for pagos

### DIFF
--- a/src/app/api/admin/verificar-pagos/route.ts
+++ b/src/app/api/admin/verificar-pagos/route.ts
@@ -23,13 +23,20 @@ export async function GET(request: NextRequest) {
     }
 
     const searchParams = request.nextUrl.searchParams
-    const estado = searchParams.get('estado') || 'EN_VERIFICACION'
+    // El parámetro "estado" puede ser una lista separada por comas o "TODOS"
+    const estadoParam = searchParams.get('estado')
     const page = parseInt(searchParams.get('page') || '1')
     const limit = parseInt(searchParams.get('limit') || '10')
     const skip = (page - 1) * limit
 
+    const where: any = {}
+    if (estadoParam && estadoParam !== 'TODOS') {
+      const estados = estadoParam.split(',')
+      where.estadoPago = { in: estados as any }
+    }
+
     const compras = await prisma.compra.findMany({
-      where: { estadoPago: estado as any },
+      where,
       include: {
         participante: {
           select: { nombre: true, celular: true, email: true }

--- a/src/features/admin/pagos/page.tsx
+++ b/src/features/admin/pagos/page.tsx
@@ -52,7 +52,8 @@ export default function PagosPage() {
 
   const fetchPagos = async () => {
     try {
-      const json = await get('/api/admin/verificar-pagos', { cache: 'no-store' })
+      // Solicitar todos los estados al backend
+      const json = await get('/api/admin/verificar-pagos?estado=TODOS', { cache: 'no-store' })
       const payload = (json as any)?.success ? (json as any).data : (json as any)
       const mapped = (payload || []).map((p: any) => ({
         id: p.id,


### PR DESCRIPTION
## Summary
- allow API route to accept optional `estado` and return all payment states
- fetch all payment states on admin pagos page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_68ae4ecdfffc833184448f6e2ca71bec