### PR TITLE
Use confirmed payment totals in admin dashboard

### DIFF
--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -22,8 +22,8 @@ export async function GET(request: NextRequest) {
         prisma.participante.count(),
         prisma.ticket.count({ where: { estado: 'PAGADO' as any } }),
         prisma.compra.aggregate({
-          where: { estadoPago: 'APROBADO' as any },
-          _sum: { monto: true }
+          where: { estadoPago: 'CONFIRMADO' as any },
+          _sum: { montoTotal: true }
         })
       ])
 
@@ -58,7 +58,7 @@ export async function GET(request: NextRequest) {
         totalEventos,
         totalParticipantes,
         totalTickets,
-        totalIngresos: ingresosTotales._sum.monto || 0
+        totalIngresos: ingresosTotales._sum.montoTotal || 0
       },
       eventosTop
     })

--- a/src/features/admin/page.tsx
+++ b/src/features/admin/page.tsx
@@ -159,7 +159,9 @@ export default function DashboardPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-yellow-200 text-sm font-medium">Ingresos Totales</p>
-                <p className="text-3xl font-bold text-white mt-1">${stats ? stats.totalIngresos.toLocaleString() : 0}</p>
+                <p className="text-3xl font-bold text-white mt-1">
+                  ${stats?.totalIngresos?.toLocaleString() ?? '0'}
+                </p>
                 <div className="flex items-center space-x-1 mt-2">
                   <TrendingUp className="h-4 w-4 text-green-400" />
                   <span className="text-green-400 text-sm">+31% vs mes anterior</span>


### PR DESCRIPTION
## Summary
- Sum confirmed purchases by `montoTotal` for admin dashboard stats
- Display total income defensively in dashboard page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and unused vars across codebase)*

------
https://chatgpt.com/codex/tasks/task_b_68ae4fe9fa908331a976c4ad58040f4b