### PR TITLE
Switch default currency to VES

### DIFF
--- a/scripts/seed/add-config-data.ts
+++ b/scripts/seed/add-config-data.ts
@@ -30,9 +30,9 @@ async function main() {
         cedula: 'V-12345678'
       },
       {
-        nombre: 'Zelle USD',
+        nombre: 'Zelle',
         tipo: 'zelle',
-        descripcion: 'Pagos en dólares vía Zelle',
+        descripcion: 'Pagos vía Zelle',
         activo: true,
         orden: 3,
         telefono: '+1 305-123-4567'

--- a/scripts/seed/seed-configuracion.ts
+++ b/scripts/seed/seed-configuracion.ts
@@ -25,17 +25,17 @@ async function seedConfiguration() {
       },
       {
         clave: 'hero_titulo',
-        valor: '1000$',
+        valor: '1000 Bs.',
         tipo: 'text'
       },
       {
         clave: 'hero_subtitulo',
-        valor: 'X 40BS',
+        valor: 'X 40 Bs.',
         tipo: 'text'
       },
       {
         clave: 'hero_descripcion',
-        valor: 'TOP 1 150$ GANA CON JESÚS',
+        valor: 'TOP 1 150 Bs. GANA CON JESÚS',
         tipo: 'text'
       },
       {

--- a/src/app/admin/eventos/nuevo/page.tsx
+++ b/src/app/admin/eventos/nuevo/page.tsx
@@ -19,7 +19,7 @@ export default function NuevoEventoPage() {
     totalBoletos: 100,
     limitePorPersona: 10,
     tiempoReserva: 30,
-    moneda: 'USD',
+    moneda: 'VES',
     zonaHoraria: 'UTC',
     portadaUrl: ''
   })

--- a/src/features/admin/configuracion/page.tsx
+++ b/src/features/admin/configuracion/page.tsx
@@ -125,8 +125,8 @@ export default function ConfiguracionPage() {
   ]
 
   const configuracionesMoneda: Array<{ clave: string; nombre: string; tipo: string; options?: { value: string; label: string }[] }> = [
-    { clave: 'currency_code', nombre: 'Código ISO (ej: VES, USD)', tipo: 'text' },
-    { clave: 'currency_symbol', nombre: 'Símbolo (ej: BsS, $)', tipo: 'text' },
+    { clave: 'currency_code', nombre: 'Código ISO (ej: VES)', tipo: 'text' },
+    { clave: 'currency_symbol', nombre: 'Símbolo (ej: Bs., $)', tipo: 'text' },
     { clave: 'currency_locale', nombre: 'Locale (ej: es-VE, es-ES)', tipo: 'text' },
     { clave: 'currency_position', nombre: 'Posición del símbolo', tipo: 'select', options: [
       { value: 'prefix', label: 'Prefijo (símbolo antes)' },
@@ -218,9 +218,9 @@ export default function ConfiguracionPage() {
             <div className="text-2xl font-bold text-slate-100 mt-1">
               {formatCurrencyFlexible(12345.67, {
                 code: editedConfig['currency_code'] || 'VES',
-                symbol: editedConfig['currency_symbol'] || 'BsS',
+                symbol: editedConfig['currency_symbol'] || 'Bs.',
                 locale: editedConfig['currency_locale'] || 'es-VE',
-                position: (editedConfig['currency_position'] as any) || 'suffix',
+                position: (editedConfig['currency_position'] as any) || 'prefix',
               })}
             </div>
           </div>

--- a/src/features/admin/metodos-pago/page.tsx
+++ b/src/features/admin/metodos-pago/page.tsx
@@ -232,7 +232,7 @@ export default function MetodosPagoPage() {
               <div className="space-y-2">
                 <label className="block text-sm font-semibold text-slate-300 uppercase tracking-wide">Moneda</label>
                 <Input
-                  placeholder="BTC, ETH, USDT, BNB, etc."
+                  placeholder="BTC, ETH, Tether, BNB, etc."
                   value={datosObj.moneda || ''}
                   onChange={(e) => updateDatos('moneda', e.target.value)}
                   className={inputClass}

--- a/src/features/landing/CompraRifa.tsx
+++ b/src/features/landing/CompraRifa.tsx
@@ -167,7 +167,7 @@ export function CompraRifa() {
         }
         // Defaults: Venezuela
         const code = map['currency_code'] || 'VES'
-        const symbol = map['currency_symbol'] || 'BsS'
+        const symbol = map['currency_symbol'] || 'Bs.'
         const locale = map['currency_locale'] || 'es-VE'
         const position = (map['currency_position'] as 'prefix'|'suffix') || 'suffix'
         setMoneda({ code, symbol, locale, position })
@@ -1010,7 +1010,7 @@ export function CompraRifa() {
                 {cantidadSeleccionada} ticket{cantidadSeleccionada > 1 ? 's' : ''} × {moneda
                   ? formatCurrencyFlexible(rifaSeleccionada?.precioPorBoleto || 0, {
                       code: moneda?.code || 'VES',
-                      symbol: moneda?.symbol || 'BsS',
+                      symbol: moneda?.symbol || 'Bs.',
                       locale: moneda?.locale || 'es-VE',
                       position: moneda?.position || 'suffix',
                     })

--- a/src/features/landing/Description.tsx
+++ b/src/features/landing/Description.tsx
@@ -41,7 +41,7 @@ export function Description({ descripcionHtml }: DescriptionProps) {
           <div class="space-y-3 text-sm">
             <div class="flex justify-between">
               <span class="font-medium">Precio por boleto:</span>
-              <span class="font-bold text-green-600">$10 USD</span>
+              <span class="font-bold text-green-600">Bs.10 VES</span>
             </div>
             <div class="flex justify-between">
               <span class="font-medium">Total de boletos:</span>
@@ -76,7 +76,7 @@ export function Description({ descripcionHtml }: DescriptionProps) {
           <div class="bg-gradient-to-r from-yellow-100 to-yellow-200 p-6 rounded-lg">
             <div class="text-4xl mb-2">🥇</div>
             <h4 class="font-bold">Primer Premio</h4>
-            <p class="text-sm text-gray-600">iPhone 15 Pro Max + $500 USD</p>
+            <p class="text-sm text-gray-600">iPhone 15 Pro Max + Bs.500 VES</p>
           </div>
           <div class="bg-gradient-to-r from-gray-100 to-gray-200 p-6 rounded-lg">
             <div class="text-4xl mb-2">🥈</div>

--- a/src/features/landing/FAQ.tsx
+++ b/src/features/landing/FAQ.tsx
@@ -56,7 +56,7 @@ export function FAQ() {
       {
         id: '7',
         pregunta: '¿Puedo comprar más de un ticket?',
-        respuesta: 'Sí, puedes comprar hasta 10 tickets por persona. Simplemente selecciona múltiples números en la grilla antes de proceder al pago. El monto total se calculará automáticamente ($10 USD por ticket).',
+        respuesta: 'Sí, puedes comprar hasta 10 tickets por persona. Simplemente selecciona múltiples números en la grilla antes de proceder al pago. El monto total se calculará automáticamente (Bs.10 VES por ticket).',
         categoria: 'compra'
       },
       {

--- a/src/features/landing/PrizeGallery.tsx
+++ b/src/features/landing/PrizeGallery.tsx
@@ -28,7 +28,7 @@ export function PrizeGallery() {
       {
         id: '1',
         titulo: '🥇 Primer Premio',
-        descripcion: 'iPhone 15 Pro Max 256GB + $500 USD en efectivo',
+        descripcion: 'iPhone 15 Pro Max 256GB + Bs.500 VES en efectivo',
         foto: '/images/premio1.jpg',
         cantidad: 1,
         // ticketGanador: { numero: 777, participante: 'María G***' } // Ejemplo post-sorteo

--- a/src/features/landing/TicketVerifier.tsx
+++ b/src/features/landing/TicketVerifier.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/Input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { VerificacionSchema, type VerificacionData } from '@/lib/validations'
-import { formatDate, formatPhone } from '@/lib/utils'
+import { formatDate, formatPhone, formatCurrencyFlexible } from '@/lib/utils'
 import { EstadoTicket } from '@/types'
 
 export function TicketVerifier() {
@@ -49,7 +49,7 @@ export function TicketVerifier() {
           },
           fechaCompra: new Date(),
           monto: 10,
-          moneda: 'USD'
+          moneda: 'VES'
         },
         tickets: data.tipo === 'celular' ? [
           {
@@ -216,7 +216,7 @@ export function TicketVerifier() {
                         </div>
                         <div>
                           <span className="font-medium">Monto:</span>
-                          <p>${result.ticket.monto} {result.ticket.moneda}</p>
+                          <p>{formatCurrencyFlexible(result.ticket.monto)} {result.ticket.moneda}</p>
                         </div>
                       </div>
 
@@ -248,7 +248,7 @@ export function TicketVerifier() {
                                 Ticket #{ticket.numero.toString().padStart(3, '0')}
                               </span>
                               <p className="text-xs text-gray-500">
-                                {formatDate(ticket.fechaCompra)} - ${ticket.monto} USD
+                                {formatDate(ticket.fechaCompra)} - {formatCurrencyFlexible(ticket.monto)} VES
                               </p>
                             </div>
                             {getEstadoBadge(ticket.estado)}

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -37,7 +37,7 @@ export async function createOrder(total: number) {
       purchase_units: [
         {
           amount: {
-            currency_code: 'USD',
+            currency_code: 'VES',
             value: total.toFixed(2)
           }
         }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,28 +5,28 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatCurrency(amount: number, currency: string = 'USD'): string {
-  return new Intl.NumberFormat('es-ES', {
+export function formatCurrency(amount: number, currency: string = 'VES'): string {
+  return new Intl.NumberFormat('es-VE', {
     style: 'currency',
     currency: currency,
   }).format(amount)
 }
 
 export type CurrencyFormatOptions = {
-  code?: string // ISO 4217 e.g., 'VES', 'USD'
-  symbol?: string // e.g., 'BsS', '$'
+  code?: string // ISO 4217 e.g., 'VES'
+  symbol?: string // e.g., 'Bs.', '$'
   locale?: string // e.g., 'es-VE'
   position?: 'prefix' | 'suffix' // Where to place symbol when custom
   minimumFractionDigits?: number
   maximumFractionDigits?: number
 }
 
-// Flexible formatter that can place a custom symbol (e.g., BsS) as suffix while still using Intl for number formatting
+// Flexible formatter that can place a custom symbol (e.g., Bs.) as suffix while still using Intl for number formatting
 export function formatCurrencyFlexible(amount: number, opts: CurrencyFormatOptions = {}): string {
   const {
-    code = 'USD',
-    symbol,
-    locale = 'es-ES',
+    code = 'VES',
+    symbol = 'Bs.',
+    locale = 'es-VE',
     position = 'prefix',
     minimumFractionDigits = 2,
     maximumFractionDigits = 2,

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -34,7 +34,7 @@ export const RifaSchema = z.object({
   // Límite por persona deshabilitado
   limitePorPersona: z.number().int().positive().optional().or(z.undefined()),
   tiempoReserva: z.number().int().positive().default(30),
-  moneda: z.string().default('USD'),
+  moneda: z.string().default('VES'),
   zonaHoraria: z.string().default('UTC')
 })
 


### PR DESCRIPTION
## Summary
- default currency helpers now use Bolívares (VES/Bs.) and locale `es-VE`
- seed scripts and landing content updated to remove USD references
- admin configuration and creation forms default to VES

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*
- `npx tsx -e "import { formatCurrency, formatCurrencyFlexible } from './src/lib/utils.ts'; console.log(formatCurrency(1234.56)); console.log(formatCurrencyFlexible(1234.56));"`

------
https://chatgpt.com/codex/tasks/task_b_68ae51f29b00833191ad4960c0ff35a9