### PR TITLE
feat(admin): filter tickets by raffle

### DIFF
--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -10,7 +10,9 @@ export const dynamic = 'force-dynamic'
 const QuerySchema = z.object({
   page: z.coerce.number().min(1).default(1),
   limit: z.coerce.number().min(1).max(100).default(20),
-  rifaId: z.string().optional(),
+  // When provided, filter tickets belonging to the specified raffle
+  // Using cuid validation to match the Rifa model id type
+  rifaId: z.string().cuid().optional(),
   estado: z.string().optional(),
   search: z.string().optional()
 })


### PR DESCRIPTION
## Summary
- allow /api/admin/tickets to filter by raffle with cuid validation
- add raffle selector and per-raffle stats on admin tickets page

## Testing
- `npm test`
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ae55591d4483319e9a6664a6123d17