### PR TITLE
feat(admin): improve button actions and feedback

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -10,7 +10,13 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "default", ...props }, ref) => {
+  ({
+    className,
+    variant = "default",
+    size = "default",
+    type = "button",
+    ...props
+  }, ref) => {
     const baseClasses = "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 transform hover:scale-[1.02] active:scale-[0.98] relative overflow-hidden group"
     
     const variants = {
@@ -31,6 +37,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <button
+        type={type}
         className={cn(
           baseClasses,
           variants[variant],

--- a/src/features/admin/eventos/page.tsx
+++ b/src/features/admin/eventos/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
-import { get, post } from '@/lib/api-client'
+import { get, post, del } from '@/lib/api-client'
 import type { ApiResponse } from '@/types'
 import { AdminHeader } from '@/features/admin/ui/AdminHeader'
 import { AdminSection } from '@/features/admin/ui/AdminSection'
@@ -61,6 +61,10 @@ export default function EventosPage() {
     ingresos: 0
   })
   const [publishing, setPublishing] = useState<string | null>(null)
+  const [actionMessage, setActionMessage] = useState<
+    { type: 'success' | 'error'; text: string } | null
+  >(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   useEffect(() => {
     const fetchEventos = async () => {
@@ -123,6 +127,25 @@ export default function EventosPage() {
     }
   }
 
+  const handleFilter = () => alert('Funcionalidad de filtros no implementada')
+
+  const handleVerTodo = () => setSearchTerm('')
+
+  const eliminarEvento = async (id: string) => {
+    if (!confirm('¿Eliminar evento?')) return
+    setDeletingId(id)
+    setActionMessage(null)
+    try {
+      await del(`/api/admin/eventos?id=${id}`)
+      setEventos(prev => prev.filter(e => e.id !== id))
+      setActionMessage({ type: 'success', text: 'Evento eliminado' })
+    } catch (err: any) {
+      setActionMessage({ type: 'error', text: err.message || 'Error al eliminar' })
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
   const getEstadoBadge = (estado: string) => {
     switch (estado) {
       case 'ACTIVO':
@@ -152,6 +175,12 @@ export default function EventosPage() {
         <Alert variant="destructive">
           <AlertTitle>Error</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {actionMessage && (
+        <Alert variant={actionMessage.type === 'error' ? 'destructive' : 'default'}>
+          <AlertTitle>{actionMessage.type === 'error' ? 'Error' : 'Éxito'}</AlertTitle>
+          <AlertDescription>{actionMessage.text}</AlertDescription>
         </Alert>
       )}
 
@@ -241,11 +270,18 @@ export default function EventosPage() {
             />
           </div>
           <div className="flex gap-3">
-            <Button variant="outline" className="border-slate-600 text-slate-300 hover:bg-slate-700/50 hover:text-white px-4 py-3 rounded-xl transition-all duration-200">
+            <Button
+              variant="outline"
+              className="border-slate-600 text-slate-300 hover:bg-slate-700/50 hover:text-white px-4 py-3 rounded-xl transition-all duration-200"
+              onClick={handleFilter}
+            >
               <Filter className="h-4 w-4 mr-2" />
               Filtrar
             </Button>
-            <Button className="bg-gradient-to-r from-teal-500 to-blue-500 hover:from-teal-600 hover:to-blue-600 text-white px-4 py-3 rounded-xl transition-all duration-200 transform hover:scale-105">
+            <Button
+              className="bg-gradient-to-r from-teal-500 to-blue-500 hover:from-teal-600 hover:to-blue-600 text-white px-4 py-3 rounded-xl transition-all duration-200 transform hover:scale-105"
+              onClick={handleVerTodo}
+            >
               <Eye className="h-4 w-4 mr-2" />
               Ver Todo
             </Button>
@@ -379,12 +415,18 @@ export default function EventosPage() {
                     )}
                   </Button>
                 )}
-                <Button 
-                  size="sm" 
-                  variant="outline" 
+                <Button
+                  size="sm"
+                  variant="outline"
                   className="border-red-500/30 text-red-400 hover:bg-red-500/20 hover:text-red-300 hover:border-red-400/50 transition-all duration-200"
+                  onClick={() => eliminarEvento(evento.id)}
+                  disabled={deletingId === evento.id}
                 >
-                  <Trash2 className="h-4 w-4" />
+                  {deletingId === evento.id ? (
+                    <LoadingSpinner className="h-4 w-4" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
                 </Button>
               </div>
             </CardContent>

--- a/src/features/admin/pagos/page.tsx
+++ b/src/features/admin/pagos/page.tsx
@@ -166,6 +166,7 @@ export default function PagosPage() {
 
   const handleExport = async () => {
     setExportError(null)
+    setActionMessage(null)
     setExporting(true)
     try {
       const res = await fetch('/api/admin/export/pagos')
@@ -181,6 +182,7 @@ export default function PagosPage() {
       link.click()
       link.remove()
       window.URL.revokeObjectURL(url)
+      setActionMessage({ type: 'success', text: 'Pagos exportados' })
     } catch (err: any) {
       setExportError(err.message || 'Error al exportar pagos')
     } finally {

--- a/src/features/admin/redes-sociales/page.tsx
+++ b/src/features/admin/redes-sociales/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { get, post, put, del } from '@/lib/api-client'
 import { AdminHeader } from '@/features/admin/ui/AdminHeader'
 import { AdminSection } from '@/features/admin/ui/AdminSection'
@@ -22,6 +23,11 @@ export default function RedesSocialesPage() {
   const [loading, setLoading] = useState(true)
   const [editingRed, setEditingRed] = useState<Partial<RedSocial> | null>(null)
   const [isCreating, setIsCreating] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [actionMessage, setActionMessage] = useState<
+    { type: 'success' | 'error'; text: string } | null
+  >(null)
 
   useEffect(() => {
     cargarRedes()
@@ -55,7 +61,8 @@ export default function RedesSocialesPage() {
 
   const guardarRed = async () => {
     if (!editingRed) return
-
+    setSaving(true)
+    setActionMessage(null)
     try {
       const url = '/api/admin/redes-sociales'
       if (isCreating) {
@@ -63,12 +70,14 @@ export default function RedesSocialesPage() {
       } else {
         await put(url, editingRed)
       }
-      alert(isCreating ? 'Red social creada exitosamente' : 'Red social actualizada exitosamente')
+      setActionMessage({ type: 'success', text: isCreating ? 'Red social creada' : 'Red social actualizada' })
       setEditingRed(null)
       cargarRedes()
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error guardando red social:', error)
-      alert('Error guardando red social')
+      setActionMessage({ type: 'error', text: error.message || 'Error guardando red social' })
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -83,14 +92,17 @@ export default function RedesSocialesPage() {
 
   const eliminarRed = async (id: string) => {
     if (!confirm('¿Estás seguro de eliminar esta red social?')) return
-
+    setDeletingId(id)
+    setActionMessage(null)
     try {
       await del(`/api/admin/redes-sociales?id=${id}`)
-      alert('Red social eliminada exitosamente')
+      setActionMessage({ type: 'success', text: 'Red social eliminada' })
       cargarRedes()
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error eliminando red social:', error)
-      alert('Error eliminando red social')
+      setActionMessage({ type: 'error', text: error.message || 'Error eliminando red social' })
+    } finally {
+      setDeletingId(null)
     }
   }
 
@@ -117,6 +129,12 @@ export default function RedesSocialesPage() {
   return (
   <div>
       <div className="max-w-7xl mx-auto space-y-6">
+        {actionMessage && (
+          <Alert variant={actionMessage.type === 'error' ? 'destructive' : 'default'}>
+            <AlertTitle>{actionMessage.type === 'error' ? 'Error' : 'Éxito'}</AlertTitle>
+            <AlertDescription>{actionMessage.text}</AlertDescription>
+          </Alert>
+        )}
         {/* Header */}
         <AdminHeader
           title="📱 Redes Sociales"
@@ -153,7 +171,15 @@ export default function RedesSocialesPage() {
                   </div>
                   <div className="flex gap-2">
                     <Button size="sm" variant="outline" onClick={() => editarRed(red)} className="border-slate-600/50 text-slate-200 hover:bg-slate-700/40">✏️</Button>
-                    <Button size="sm" variant="outline" onClick={() => eliminarRed(red.id)} className="border-red-600/40 text-red-300 hover:bg-red-600/10">🗑️</Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => eliminarRed(red.id)}
+                      className="border-red-600/40 text-red-300 hover:bg-red-600/10"
+                      disabled={deletingId === red.id}
+                    >
+                      {deletingId === red.id ? <LoadingSpinner className="h-4 w-4" /> : '🗑️'}
+                    </Button>
                   </div>
                 </div>
               </CardContent>
@@ -266,16 +292,18 @@ export default function RedesSocialesPage() {
             </div>
 
             <div className="flex space-x-3 p-6 bg-slate-800/40 rounded-b-2xl">
-              <Button 
-                onClick={guardarRed} 
+              <Button
+                onClick={guardarRed}
                 className="flex-1"
+                disabled={saving}
               >
-                💾 Guardar
+                {saving ? 'Guardando…' : '💾 Guardar'}
               </Button>
-              <Button 
+              <Button
                 onClick={() => setEditingRed(null)}
                 variant="outline"
                 className="flex-1 border-slate-600/50 text-slate-200 hover:bg-slate-700/40"
+                disabled={saving}
               >
                 ❌ Cancelar
               </Button>

--- a/src/features/admin/tickets/page.tsx
+++ b/src/features/admin/tickets/page.tsx
@@ -44,6 +44,9 @@ export default function TicketsPage() {
   const limit = 10
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
+  const [actionMessage, setActionMessage] = useState<
+    { type: 'success' | 'error'; text: string } | null
+  >(null)
   const [stats, setStats] = useState({
     disponibles: 0,
     vendidos: 0,
@@ -157,6 +160,7 @@ export default function TicketsPage() {
   const handleExport = async () => {
     if (!selectedRifa) return
     setExportError(null)
+    setActionMessage(null)
     setExporting(true)
     try {
       const res = await fetch(`/api/admin/export/tickets?rifaId=${selectedRifa}`)
@@ -172,6 +176,7 @@ export default function TicketsPage() {
       link.click()
       link.remove()
       window.URL.revokeObjectURL(url)
+      setActionMessage({ type: 'success', text: 'Tickets exportados' })
     } catch (err: any) {
       setExportError(err.message || 'Error al exportar tickets')
     } finally {
@@ -185,6 +190,12 @@ export default function TicketsPage() {
         <Alert variant="destructive">
           <AlertTitle>Error</AlertTitle>
           <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      {actionMessage && (
+        <Alert variant={actionMessage.type === 'error' ? 'destructive' : 'default'}>
+          <AlertTitle>{actionMessage.type === 'error' ? 'Error' : 'Éxito'}</AlertTitle>
+          <AlertDescription>{actionMessage.text}</AlertDescription>
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary
- default buttons to `type="button"`
- wire up admin buttons with click handlers and success/error alerts
- show export success state for payments and tickets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae5a16e6b483318d2604d066ccc43d