### PR TITLE
refactor: tighten types and generics

### DIFF
--- a/src/features/admin/eventos/page.tsx
+++ b/src/features/admin/eventos/page.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { get, post, del } from '@/lib/api-client'
-import type { ApiResponse } from '@/types'
+import type { ApiResponse, Rifa } from '@/types'
 import { AdminHeader } from '@/features/admin/ui/AdminHeader'
 import { AdminSection } from '@/features/admin/ui/AdminSection'
 import {
@@ -116,7 +116,7 @@ export default function EventosPage() {
   const publicarRifa = async (id: string) => {
     try {
       setPublishing(id)
-      const res = await post<any>(`/api/admin/rifas/${id}/publicar`)
+        const res = await post<ApiResponse<Rifa>>(`/api/admin/rifas/${id}/publicar`)
       if (!res?.success) throw new Error(res?.error || 'No se pudo publicar')
       // Refrescar estado local a ACTIVO
       setEventos((prev) => prev.map(e => e.id === id ? { ...e, estado: 'ACTIVO' } : e))

--- a/src/features/admin/login/page.tsx
+++ b/src/features/admin/login/page.tsx
@@ -14,18 +14,29 @@ interface LoginForm {
   rememberMe: boolean
 }
 
-interface LoginResponse {
-  success: boolean
-  user?: {
-    id: string
-    nombre: string
-    email: string
-    rol: string
+  interface LoginResponse {
+    success: boolean
+    user?: {
+      id: string
+      nombre: string
+      email: string
+      rol: string
+    }
+    message?: string
+    error?: string
+    details?: unknown
   }
-  message?: string
-  error?: string
-  details?: any
-}
+
+  interface AuthMeResponse {
+    success: boolean
+    user?: {
+      id: string
+      nombre: string
+      email: string
+      rol: string
+    }
+    error?: string
+  }
 
 function LoginContent() {
   const router = useRouter()
@@ -46,7 +57,7 @@ function LoginContent() {
   useEffect(() => {
     const checkAuthStatus = async () => {
       try {
-        const data = await get('/api/auth/me') as any
+          const data = await get<AuthMeResponse>('/api/auth/me')
         if (data?.success && ['ADMIN', 'SUPER_ADMIN'].includes(data?.user?.rol)) {
           router.push(redirectTo)
         }

--- a/src/features/admin/notificaciones/ajustes/page.tsx
+++ b/src/features/admin/notificaciones/ajustes/page.tsx
@@ -4,10 +4,29 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { get, put, post } from '@/lib/api-client'
+import type { ApiResponse } from '@/types'
 import { CONFIG } from '@/lib/config'
 
-interface EmailTemplate { subject?: string; body?: string }
-interface SmsTemplate { body?: string }
+  interface EmailTemplate { subject?: string; body?: string }
+  interface SmsTemplate { body?: string }
+
+  interface ConfigData {
+    SMTP_ENABLED?: boolean | string
+    SMS_ENABLED?: boolean | string
+    EMAIL_TEMPLATES?: Record<string, EmailTemplate>
+    SMS_TEMPLATES?: Record<string, SmsTemplate>
+    [key: string]: unknown
+  }
+
+  interface AuthMeResponse {
+    success: boolean
+    user?: {
+      id: string
+      nombre: string
+      email: string
+      rol: string
+    }
+  }
 
 export default function NotificacionesAjustesPage() {
   const tipos = CONFIG.NOTIFICACIONES.TIPOS_VALIDOS
@@ -21,8 +40,8 @@ export default function NotificacionesAjustesPage() {
   useEffect(() => {
     const cargar = async () => {
       try {
-        const configResp = await get<any>('/api/admin/configuracion')
-        const data = configResp.data || configResp
+          const configResp = await get<ApiResponse<ConfigData>>('/api/admin/configuracion')
+          const data = configResp.data ?? {}
         setSmtpEnabled(data.SMTP_ENABLED === true || data.SMTP_ENABLED === 'true')
         setSmsEnabled(data.SMS_ENABLED === true || data.SMS_ENABLED === 'true')
         setEmailTemplates(data.EMAIL_TEMPLATES || {})
@@ -31,7 +50,7 @@ export default function NotificacionesAjustesPage() {
         console.error('Error cargando configuración', err)
       }
       try {
-        const me = await get<any>('/api/auth/me')
+          const me = await get<AuthMeResponse>('/api/auth/me')
         if (me.success && me.user?.email) setTestEmail(me.user.email)
       } catch {}
     }

--- a/src/features/landing/TicketVerifier.tsx
+++ b/src/features/landing/TicketVerifier.tsx
@@ -11,9 +11,35 @@ import { VerificacionSchema, type VerificacionData } from '@/lib/validations'
 import { formatDate, formatPhone, formatCurrencyFlexible } from '@/lib/utils'
 import { EstadoTicket } from '@/types'
 
-export function TicketVerifier() {
-  const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState<any>(null)
+  interface TicketInfo {
+    numero: number
+    estado: EstadoTicket
+    participante: {
+      nombre: string
+      celular: string
+      email?: string
+    }
+    fechaCompra: Date
+    monto: number
+    moneda: string
+  }
+
+  interface TicketSummary {
+    numero: number
+    estado: EstadoTicket
+    fechaCompra: Date
+    monto: number
+  }
+
+  interface VerificationResult {
+    ticket?: TicketInfo
+    tickets?: TicketSummary[] | null
+    error?: string
+  }
+
+  export function TicketVerifier() {
+    const [loading, setLoading] = useState(false)
+    const [result, setResult] = useState<VerificationResult | null>(null)
 
   const {
     register,
@@ -38,34 +64,34 @@ export function TicketVerifier() {
       await new Promise(resolve => setTimeout(resolve, 1000))
 
       // Datos de ejemplo
-      const exampleResult = {
-        ticket: {
-          numero: data.busqueda.includes('123') ? 123 : Math.floor(Math.random() * 1000),
-          estado: EstadoTicket.PAGADO,
-          participante: {
-            nombre: 'Juan P***',
-            celular: formatPhone('+1234567890'),
-            email: 'j***@email.com'
-          },
-          fechaCompra: new Date(),
-          monto: 10,
-          moneda: 'VES'
-        },
-        tickets: data.tipo === 'celular' ? [
-          {
-            numero: 123,
+        const exampleResult: VerificationResult = {
+          ticket: {
+            numero: data.busqueda.includes('123') ? 123 : Math.floor(Math.random() * 1000),
             estado: EstadoTicket.PAGADO,
+            participante: {
+              nombre: 'Juan P***',
+              celular: formatPhone('+1234567890'),
+              email: 'j***@email.com'
+            },
             fechaCompra: new Date(),
-            monto: 10
+            monto: 10,
+            moneda: 'VES'
           },
-          {
-            numero: 456,
-            estado: EstadoTicket.RESERVADO,
-            fechaCompra: new Date(),
-            monto: 10
-          }
-        ] : null
-      }
+          tickets: data.tipo === 'celular' ? [
+            {
+              numero: 123,
+              estado: EstadoTicket.PAGADO,
+              fechaCompra: new Date(),
+              monto: 10
+            },
+            {
+              numero: 456,
+              estado: EstadoTicket.RESERVADO,
+              fechaCompra: new Date(),
+              monto: 10
+            }
+          ] : null
+        }
 
       setResult(exampleResult)
     } catch (error) {
@@ -241,8 +267,8 @@ export function TicketVerifier() {
                       </h3>
                       
                       <div className="space-y-2">
-                        {result.tickets.map((ticket: any, index: number) => (
-                          <div key={index} className="flex justify-between items-center p-3 bg-white rounded border">
+                          {result.tickets.map((ticket: TicketSummary, index: number) => (
+                            <div key={index} className="flex justify-between items-center p-3 bg-white rounded border">
                             <div>
                               <span className="font-medium">
                                 Ticket #{ticket.numero.toString().padStart(3, '0')}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,9 +1,9 @@
 import { CONFIG } from './config'
 
-export class HttpError extends Error {
+export class HttpError<T = unknown> extends Error {
   status: number
-  details?: any
-  constructor(message: string, status: number, details?: any) {
+  details?: T
+  constructor(message: string, status: number, details?: T) {
     super(message)
     this.name = 'HttpError'
     this.status = status
@@ -26,7 +26,7 @@ function buildUrl(path: string) {
   return `${BASE_URL}${path}`
 }
 
-async function request<T>(method: string, path: string, body?: any, options: RequestInit = {}): Promise<T> {
+async function request<TResponse, TBody = unknown>(method: string, path: string, body?: TBody, options: RequestInit = {}): Promise<TResponse> {
   const url = buildUrl(path)
   const { credentials = 'include', headers: initHeaders, ...rest } = options
   const headers = new Headers(initHeaders as HeadersInit)
@@ -48,26 +48,26 @@ async function request<T>(method: string, path: string, body?: any, options: Req
       credentials,
     })
 
-    if (!res.ok) {
-      let message = res.statusText
-      let details: any = undefined
-      try {
-        const errorData = await res.json()
-        message = errorData.message || errorData.mensaje || errorData.error || message
-        details = errorData.details ?? errorData.detalles
-      } catch {}
-      throw new HttpError(message, res.status, details)
-    }
+      if (!res.ok) {
+        let message = res.statusText
+        let details: unknown = undefined
+        try {
+          const errorData = await res.json()
+          message = errorData.message || errorData.mensaje || errorData.error || message
+          details = errorData.details ?? errorData.detalles
+        } catch {}
+        throw new HttpError(message, res.status, details)
+      }
 
-    if (res.status === 204) {
-      return undefined as unknown as T
-    }
+      if (res.status === 204) {
+        return undefined as unknown as TResponse
+      }
 
-    const contentType = res.headers.get('content-type')
-    if (contentType && contentType.includes('application/json')) {
-      return (await res.json()) as T
-    }
-    return (await res.text()) as unknown as T
+      const contentType = res.headers.get('content-type')
+      if (contentType && contentType.includes('application/json')) {
+        return (await res.json()) as TResponse
+      }
+      return (await res.text()) as unknown as TResponse
   } catch (err) {
     if (typeof window === 'undefined') {
       const { logError } = await import('./logger')
@@ -78,10 +78,15 @@ async function request<T>(method: string, path: string, body?: any, options: Req
   }
 }
 
-export const get = <T>(path: string, options?: RequestInit) => request<T>('GET', path, undefined, options)
-export const post = <T>(path: string, body?: any, options?: RequestInit) => request<T>('POST', path, body, options)
-export const put = <T>(path: string, body?: any, options?: RequestInit) => request<T>('PUT', path, body, options)
-export const patch = <T>(path: string, body?: any, options?: RequestInit) => request<T>('PATCH', path, body, options)
-export const del = <T>(path: string, options?: RequestInit) => request<T>('DELETE', path, undefined, options)
+export const get = <TResponse>(path: string, options?: RequestInit) =>
+  request<TResponse, undefined>('GET', path, undefined, options)
+export const post = <TResponse, TBody = unknown>(path: string, body?: TBody, options?: RequestInit) =>
+  request<TResponse, TBody>('POST', path, body, options)
+export const put = <TResponse, TBody = unknown>(path: string, body?: TBody, options?: RequestInit) =>
+  request<TResponse, TBody>('PUT', path, body, options)
+export const patch = <TResponse, TBody = unknown>(path: string, body?: TBody, options?: RequestInit) =>
+  request<TResponse, TBody>('PATCH', path, body, options)
+export const del = <TResponse>(path: string, options?: RequestInit) =>
+  request<TResponse, undefined>('DELETE', path, undefined, options)
 
 export default { get, post, put, patch, del }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,16 @@
+export interface RifaConfig {
+  [key: string]: unknown
+}
+
+export interface TicketExtras {
+  numeros?: number[]
+  [key: string]: unknown
+}
+
+export interface AuditLogPayload {
+  [key: string]: unknown
+}
+
 export interface Rifa {
   id: string
   nombre: string
@@ -15,7 +28,7 @@ export interface Rifa {
   metaTitulo?: string
   metaDescripcion?: string
   imagenOg?: string
-  configuracion?: any
+  configuracion?: RifaConfig
   createdAt: Date
   updatedAt: Date
   premios?: Premio[]
@@ -64,7 +77,7 @@ export interface Ticket {
   monto?: number
   fechaReserva?: Date
   fechaVencimiento?: Date
-  numerosExtra?: any
+  numerosExtra?: TicketExtras
   notas?: string
   createdAt: Date
   updatedAt: Date
@@ -154,7 +167,7 @@ export interface AuditLog {
   accion: string
   entidad: string
   entidadId: string
-  payload?: any
+  payload?: AuditLogPayload
   ip?: string
   userAgent?: string
   createdAt: Date
@@ -202,7 +215,7 @@ export enum EstadoSorteo {
 }
 
 // Tipos de respuesta de API
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string


### PR DESCRIPTION
## Summary
- introduce explicit interfaces for Rifa configuration, ticket extras and audit payload
- refactor API client to use generics and unknown instead of any
- update feature components to leverage the stricter types

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, unused vars across existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68ae76237a8083318f654c5c9f1c4e0d